### PR TITLE
Rename HelloWorld to Grid with ShimmeredDetailsList and theming

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { DetailsList, IColumn } from '@fluentui/react/lib/DetailsList';
+import { IColumn } from '@fluentui/react/lib/DetailsList';
+import { ShimmeredDetailsList } from '@fluentui/react/lib/ShimmeredDetailsList';
+import { ThemeProvider, ITheme } from '@fluentui/react';
 import { initializeIcons } from '@fluentui/font-icons-mdl2';
 
 // Cast to a typed function to satisfy lint rules.
 (initializeIcons as () => void)();
 
-/** Props accepted by the HelloWorld component. */
-export interface IHelloWorldProps {
+/** Props accepted by the Grid component. */
+export interface IGridProps {
   /** Display name shown above the list. */
   name: string;
+  /** Optional theme applied to the list. */
+  theme?: ITheme;
 }
 
 interface IItem {
@@ -17,7 +21,7 @@ interface IItem {
   value: number;
 }
 
-export class HelloWorld extends React.Component<IHelloWorldProps> {
+export class Grid extends React.Component<IGridProps> {
   private readonly _columns: IColumn[] = [
     { key: 'name', name: 'Name', fieldName: 'name', minWidth: 100, maxWidth: 200, isResizable: true },
     { key: 'value', name: 'Value', fieldName: 'value', minWidth: 50, maxWidth: 100, isResizable: true }
@@ -30,10 +34,12 @@ export class HelloWorld extends React.Component<IHelloWorldProps> {
 
   public render(): React.ReactNode {
     return (
-      <div>
-        <h3>{this.props.name}</h3>
-        <DetailsList items={this._items} columns={this._columns} />
-      </div>
+      <ThemeProvider theme={this.props.theme}>
+        <div>
+          <h3>{this.props.name}</h3>
+          <ShimmeredDetailsList items={this._items} columns={this._columns} />
+        </div>
+      </ThemeProvider>
     );
   }
 }

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -1,6 +1,7 @@
 import { IInputs, IOutputs } from "./generated/ManifestTypes";
-import { HelloWorld, IHelloWorldProps } from "./HelloWorld";
+import { Grid, IGridProps } from "./Grid";
 import * as React from "react";
+import { ITheme } from '@fluentui/react';
 
 export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, IOutputs> {
     private notifyOutputChanged: () => void;
@@ -33,9 +34,13 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
      * @returns ReactElement root react element for the control
      */
     public updateView(context: ComponentFramework.Context<IInputs>): React.ReactElement {
-        const props: IHelloWorldProps = { name: 'Power Apps' };
+        const theme = (context as unknown as { fluentTheme?: ITheme }).fluentTheme;
+        const props: IGridProps = {
+            name: 'Power Apps',
+            theme,
+        };
         return React.createElement(
-            HelloWorld, props
+            Grid, props
         );
     }
 


### PR DESCRIPTION
## Summary
- replace `HelloWorld` with new `Grid` component using `ShimmeredDetailsList`
- add `ThemeProvider` support to allow dynamic theming
- update control to render `Grid` and pass through the current theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint validation error)

------
https://chatgpt.com/codex/tasks/task_e_68a894b570b4832c83df8c9dc3e0791e