### PR TITLE
Handle NaN values in grid column mapping

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -453,6 +453,12 @@ function mapToGridColumn(
         return defaultIfNullish(value, undefined);
     }
     function defaultIfNullish<T>(value: T, defaultValue: T) {
-        return value ?? defaultValue;
+        if (value === null || value === undefined) {
+            return defaultValue;
+        }
+        // Treat NaN as nullish for numeric values
+        return typeof value === 'number' && isNaN(value)
+            ? defaultValue
+            : value;
     }
 }


### PR DESCRIPTION
## Summary
- avoid NaN widths by treating null, undefined, or NaN column values as undefined

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 109 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a89f5f92a8832cbb085b4f533f3ff1