### PR TITLE
Fix type handling in Grid component

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -102,7 +102,7 @@ export const Grid = React.memo((props: GridProps) => {
           minWidth: c.visualSizeFactor ?? 100,
           isResizable: true,
           isSorted: !!sort,
-          isSortedDescending: sort ? sort.sortDirection === 1 || sort.sortDirection === '1' : undefined,
+          isSortedDescending: sort ? Number(sort.sortDirection) === 1 : undefined,
         } as IColumn;
       }),
     [datasetColumns, sorting],
@@ -124,8 +124,10 @@ export const Grid = React.memo((props: GridProps) => {
   );
 
   const onColumnHeaderClick = React.useCallback(
-    (ev: React.MouseEvent<HTMLElement>, column: IColumn) => {
-      onSort(column.key, column.isSorted ? !column.isSortedDescending : false);
+    (ev?: React.MouseEvent<HTMLElement>, column?: IColumn) => {
+      if (column) {
+        onSort(column.key, column.isSorted ? !column.isSortedDescending : false);
+      }
     },
     [onSort],
   );


### PR DESCRIPTION
## Summary
- handle sortDirection consistently by converting to number
- accept optional column header click parameters and guard

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: 67 errors, e.g., `@typescript-eslint/no-unsafe-assignment`)*
- `npm run build` *(fails: 67 ESLint errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@fluentui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68aced88b7f0832ca48e80323431dad6