### PR TITLE
Guard style values against NaN

### DIFF
--- a/DetailsListVOA/GridCell.tsx
+++ b/DetailsListVOA/GridCell.tsx
@@ -157,7 +157,13 @@ function wrapContent(cellContents: JSX.Element, column: IGridColumn, isBlank: bo
     return cellContents;
 }
 function undefinedIf<T>(flag: boolean, value: T): T | undefined {
-    return flag ? value : undefined;
+    if (!flag) {
+        return undefined;
+    }
+    if (typeof value === 'number' && isNaN(value)) {
+        return undefined;
+    }
+    return value;
 }
 
 function getColorTagCell(


### PR DESCRIPTION
## Summary
- avoid applying style values when they are NaN

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment / call / argument errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acf0babc5c832cafb80e74e5ec6866