### PR TITLE
fix: guard grid column width

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -95,11 +95,15 @@ export const Grid = React.memo((props: GridProps) => {
     () =>
       datasetColumns.map((c) => {
         const sort = sorting.find((s) => s.name === c.name);
+        const visualSize =
+          typeof c.visualSizeFactor === 'number' && !isNaN(c.visualSizeFactor)
+            ? c.visualSizeFactor
+            : 100;
         return {
           key: c.name,
           name: c.displayName,
           fieldName: c.name,
-          minWidth: c.visualSizeFactor ?? 100,
+          minWidth: visualSize,
           isResizable: true,
           isSorted: !!sort,
           isSortedDescending: sort ? Number(sort.sortDirection) === 1 : undefined,


### PR DESCRIPTION
## Summary
- avoid passing NaN widths to grid columns by validating visualSizeFactor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68acf3e46980832cbe9500fb4367e9fd