### PR TITLE
Fix selection typing for sample grid

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -25,7 +25,7 @@ export interface GridProps {
   shimmer: boolean;
   itemsLoading: boolean;
   selectionType: SelectionMode;
-  selection: ISelection;
+  selection: ISelection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord>;
   onNavigate: (item?: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord) => void;
   onSort: (name: string, desc: boolean) => void;
   sorting: ComponentFramework.PropertyHelper.DataSetApi.SortStatus[];

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -20,7 +20,8 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
 
     public updateView(context: ComponentFramework.Context<IInputs>): React.ReactElement {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-        const selection: ISelection = new Selection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord>();
+        const selection: ISelection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord> =
+            new Selection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord>({});
         const componentRef = React.createRef<IDetailsList>();
 
         // Provide default columns and records so the grid renders with sample data on initial load
@@ -55,7 +56,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
                 getRecordId: () => id,
                 getValue: (columnName: string) => data[columnName as keyof RecordData],
                 getFormattedValue: (columnName: string) => data[columnName as keyof RecordData],
-                getNamedReference: () => ({ id, name: data.col1, entityType: 'dummy' }),
+                getNamedReference: () => ({ id: { guid: id }, etn: 'dummy', name: data.col1 }),
             };
             records[id] = record;
             sortedRecordIds.push(id);


### PR DESCRIPTION
## Summary
- fix selection typing to match Fluent UI's generics
- return proper entity reference with guid id
- update GridProps selection typing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7e4f5678832ca0916dbfb9e24030