### PR TITLE
Implement getKey in Selection initialization

### DIFF
--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -21,7 +21,9 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     public updateView(context: ComponentFramework.Context<IInputs>): React.ReactElement {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
         const selection: ISelection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord> =
-            new Selection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord>({});
+            new Selection<ComponentFramework.PropertyHelper.DataSetApi.EntityRecord>({
+                getKey: (item: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord) => item.getRecordId(),
+            });
         const componentRef = React.createRef<IDetailsList>();
 
         // Provide default columns and records so the grid renders with sample data on initial load


### PR DESCRIPTION
## Summary
- provide getKey function when creating Selection to satisfy ISelectionOptions

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@fluentui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7f9f8088832ca449eed4f40b9178