### PR TITLE
feat: add page size property and dataset pagination

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -27,6 +27,8 @@
 
     <!-- Optional canvas page or url to open when a row is invoked -->
     <property name="navigationTarget" display-name-key="NavigationTarget" description-key="NavigationTarget description" of-type="SingleLine.Text" usage="input" required="false" />
+    <!-- Number of records shown per page -->
+    <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>
       <code path="index.ts" order="1"/>

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -138,11 +138,14 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             });
         }
 
-        const pageSize = 20;
+        const pageSize = context.parameters.pageSize.raw ?? 20;
+        if (dataset.paging.pageSize !== pageSize) {
+            dataset.paging.setPageSize(pageSize);
+        }
         const start = this.currentPage * pageSize;
         const pageIds = filteredIds.slice(start, start + pageSize);
         const canPrev = this.currentPage > 0;
-        const canNext = start + pageSize < filteredIds.length;
+        const canNext = start + pageSize < filteredIds.length || dataset.paging.hasNextPage;
 
         const onNavigate = (
             item?: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord,
@@ -167,6 +170,10 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
 
         const onNextPage = (): void => {
             if (canNext) {
+                const nextStart = (this.currentPage + 1) * pageSize;
+                if (nextStart >= filteredIds.length && dataset.paging.hasNextPage) {
+                    dataset.paging.loadNextPage();
+                }
                 this.currentPage += 1;
                 this.notifyOutputChanged();
             }


### PR DESCRIPTION
## Summary
- add optional `pageSize` manifest property for page length configuration
- load additional dataset pages when navigating forward

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@fluentui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9024f338832c82d1983b98314c88