### PR TITLE
feat: allow display name editing and refine pagination

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -13,8 +13,8 @@ import {
   ThemeProvider,
   TextField,
   PrimaryButton,
-  DefaultButton,
   Stack,
+  Text,
 } from '@fluentui/react';
 import * as React from 'react';
 import { NoFields } from './NoFields';
@@ -49,6 +49,8 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   searchText?: string;
+  displayName: string;
+  onUpdateDisplayName: (name: string) => void;
 }
 
 const defaultTheme = createTheme({
@@ -110,6 +112,8 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     searchText,
+    displayName,
+    onUpdateDisplayName,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -166,6 +170,11 @@ export const Grid = React.memo((props: GridProps) => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
+        <TextField
+          label="Display Name"
+          value={displayName}
+          onChange={(_, v) => onUpdateDisplayName(v ?? '')}
+        />
         <TextField placeholder="Search" value={searchText} onChange={(_, v) => onSearch(v ?? '')} />
         <ShimmeredDetailsList
           componentRef={componentRef}
@@ -185,9 +194,15 @@ export const Grid = React.memo((props: GridProps) => {
           <PrimaryButton text="Previous" onClick={onPrevPage} disabled={!canPrev} />
           {Array.from({ length: totalPages }, (_, i) =>
             i === currentPage ? (
-              <PrimaryButton key={i} text={`${i + 1}`} disabled />
+              <Text key={i} style={{ fontWeight: 600 }}>{i + 1}</Text>
             ) : (
-              <DefaultButton key={i} text={`${i + 1}`} onClick={() => onSetPage(i)} />
+              <Text
+                key={i}
+                style={{ cursor: 'pointer' }}
+                onClick={() => onSetPage(i)}
+              >
+                {i + 1}
+              </Text>
             ),
           )}
           <PrimaryButton text="Next" onClick={onNextPage} disabled={!canNext} />

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -10,6 +10,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     private selectedTaskId?: string;
     private searchText = "";
     private currentPage = 0;
+    private displayName = "Details List";
 
     constructor() {
         // Empty
@@ -198,6 +199,11 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
+        const onUpdateDisplayName = (name: string): void => {
+            this.displayName = name;
+            this.notifyOutputChanged();
+        };
+
         const props: GridProps = {
             datasetColumns,
             records,
@@ -220,6 +226,8 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchText: this.searchText,
+            displayName: this.displayName,
+            onUpdateDisplayName,
         };
 
         return React.createElement(Grid, props);


### PR DESCRIPTION
## Summary
- allow users to update the list display name via text field
- show pagination numbers as plain text to remove button boxes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@fluentui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68ada24cee6c832c8c9471d5c5fe1448