### PR TITLE
Enable column header edits and refine list layout

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -12,9 +12,9 @@ import {
   ShimmeredDetailsList,
   ThemeProvider,
   TextField,
-  PrimaryButton,
   Stack,
   Text,
+  DefaultButton,
 } from '@fluentui/react';
 import * as React from 'react';
 import { NoFields } from './NoFields';
@@ -49,8 +49,7 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   searchText?: string;
-  displayName: string;
-  onUpdateDisplayName: (name: string) => void;
+  onUpdateColumnDisplayName: (name: string, displayName: string) => void;
 }
 
 const defaultTheme = createTheme({
@@ -112,8 +111,7 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     searchText,
-    displayName,
-    onUpdateDisplayName,
+    onUpdateColumnDisplayName,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -170,12 +168,22 @@ export const Grid = React.memo((props: GridProps) => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
+        <Stack tokens={{ childrenGap: 8 }}>
+          {datasetColumns.map((col) => (
+            <TextField
+              key={col.name}
+              label={`${col.name} Display Name`}
+              value={col.displayName}
+              onChange={(_, v) => onUpdateColumnDisplayName(col.name, v ?? '')}
+            />
+          ))}
+        </Stack>
         <TextField
-          label="Display Name"
-          value={displayName}
-          onChange={(_, v) => onUpdateDisplayName(v ?? '')}
+          placeholder="Search"
+          value={searchText}
+          onChange={(_, v) => onSearch(v ?? '')}
+          style={{ marginBottom: 16 }}
         />
-        <TextField placeholder="Search" value={searchText} onChange={(_, v) => onSearch(v ?? '')} />
         <ShimmeredDetailsList
           componentRef={componentRef}
           items={items}
@@ -190,22 +198,37 @@ export const Grid = React.memo((props: GridProps) => {
           compact={compact}
           isHeaderVisible={isHeaderVisible}
         />
-        <Stack horizontal tokens={{ childrenGap: 8 }} style={{ marginTop: 8 }}>
-          <PrimaryButton text="Previous" onClick={onPrevPage} disabled={!canPrev} />
-          {Array.from({ length: totalPages }, (_, i) =>
-            i === currentPage ? (
-              <Text key={i} style={{ fontWeight: 600 }}>{i + 1}</Text>
-            ) : (
-              <Text
-                key={i}
-                style={{ cursor: 'pointer' }}
-                onClick={() => onSetPage(i)}
-              >
-                {i + 1}
-              </Text>
-            ),
-          )}
-          <PrimaryButton text="Next" onClick={onNextPage} disabled={!canNext} />
+        <Stack
+          horizontal
+          tokens={{ childrenGap: 8 }}
+          style={{ marginTop: 8 }}
+          verticalAlign="center"
+        >
+          <DefaultButton
+            text="Previous"
+            onClick={onPrevPage}
+            disabled={!canPrev}
+            styles={{ root: { height: 32, padding: '0 8px' } }}
+          />
+          {Array.from({ length: totalPages }, (_, i) => (
+            <Text
+              key={i}
+              style={{
+                cursor: 'pointer',
+                fontWeight: i === currentPage ? 600 : undefined,
+                fontSize: 14,
+              }}
+              onClick={() => (i === currentPage ? undefined : onSetPage(i))}
+            >
+              {i + 1}
+            </Text>
+          ))}
+          <DefaultButton
+            text="Next"
+            onClick={onNextPage}
+            disabled={!canNext}
+            styles={{ root: { height: 32, padding: '0 8px' } }}
+          />
         </Stack>
       </div>
     </ThemeProvider>

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -10,7 +10,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     private selectedTaskId?: string;
     private searchText = "";
     private currentPage = 0;
-    private displayName = "Details List";
+    private columnDisplayNames: Record<string, string> = {};
 
     constructor() {
         // Empty
@@ -38,11 +38,12 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
 
         const datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[] = dataset.columns.map((c) => ({
             ...c,
+            displayName: this.columnDisplayNames[c.name] ?? c.displayName,
         }));
 
         datasetColumns.push({
             name: "taskstatus",
-            displayName: "Task Status",
+            displayName: this.columnDisplayNames.taskstatus ?? "Task Status",
             dataType: "SingleLine.Text",
             alias: "taskstatus",
             order: datasetColumns.length + 1,
@@ -50,7 +51,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         datasetColumns.push({
             name: "assignedto",
-            displayName: "Assigned To",
+            displayName: this.columnDisplayNames.assignedto ?? "Assigned To",
             dataType: "SingleLine.Text",
             alias: "assignedto",
             order: datasetColumns.length + 1,
@@ -58,7 +59,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         datasetColumns.push({
             name: "tasktitle",
-            displayName: "Task Title",
+            displayName: this.columnDisplayNames.tasktitle ?? "Task Title",
             dataType: "SingleLine.Text",
             alias: "tasktitle",
             order: datasetColumns.length + 1,
@@ -66,7 +67,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         datasetColumns.push({
             name: "action",
-            displayName: "Action",
+            displayName: this.columnDisplayNames.action ?? "Action",
             dataType: "SingleLine.Text",
             alias: "action",
             order: datasetColumns.length + 1,
@@ -199,8 +200,8 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
-        const onUpdateDisplayName = (name: string): void => {
-            this.displayName = name;
+        const onUpdateColumnDisplayName = (name: string, value: string): void => {
+            this.columnDisplayNames[name] = value;
             this.notifyOutputChanged();
         };
 
@@ -226,8 +227,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchText: this.searchText,
-            displayName: this.displayName,
-            onUpdateDisplayName,
+            onUpdateColumnDisplayName,
         };
 
         return React.createElement(Grid, props);


### PR DESCRIPTION
## Summary
- allow overriding each column's display name
- add spacing before the grid's search box and tidy up pagination buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ada4a5de88832cbbeba487d5808214