### PR TITLE
Allow configurable column display names via input property

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -29,6 +29,8 @@
     <property name="navigationTarget" display-name-key="NavigationTarget" description-key="NavigationTarget description" of-type="SingleLine.Text" usage="input" required="false" />
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
+    <!-- Optional mapping of column logical names to display names as JSON -->
+    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.TextArea" usage="input" required="false" />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>
       <code path="index.ts" order="1"/>

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -49,7 +49,6 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   searchText?: string;
-  onUpdateColumnDisplayName: (name: string, displayName: string) => void;
 }
 
 const defaultTheme = createTheme({
@@ -111,7 +110,6 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     searchText,
-    onUpdateColumnDisplayName,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -168,16 +166,6 @@ export const Grid = React.memo((props: GridProps) => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
-        <Stack tokens={{ childrenGap: 8 }}>
-          {datasetColumns.map((col) => (
-            <TextField
-              key={col.name}
-              label={`${col.name} Display Name`}
-              value={col.displayName}
-              onChange={(_, v) => onUpdateColumnDisplayName(col.name, v ?? '')}
-            />
-          ))}
-        </Stack>
         <TextField
           placeholder="Search"
           value={searchText}

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -10,7 +10,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     private selectedTaskId?: string;
     private searchText = "";
     private currentPage = 0;
-    private columnDisplayNames: Record<string, string> = {};
 
     constructor() {
         // Empty
@@ -29,6 +28,13 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const taskIdField = context.parameters.taskIdField.raw ?? "taskid";
         const taskEntity = context.parameters.taskEntity.raw ?? "";
         const navigationTarget = context.parameters.navigationTarget.raw ?? "";
+        const columnDisplayNamesRaw = context.parameters.columnDisplayNames?.raw ?? "";
+        let columnDisplayNames: Record<string, string>;
+        try {
+            columnDisplayNames = columnDisplayNamesRaw ? JSON.parse(columnDisplayNamesRaw) as Record<string, string> : {};
+        } catch {
+            columnDisplayNames = {};
+        }
 
         const selection: ISelection<IObjectWithKey> = new Selection<IObjectWithKey>({
             getKey: (item: IObjectWithKey) =>
@@ -38,12 +44,12 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
 
         const datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[] = dataset.columns.map((c) => ({
             ...c,
-            displayName: this.columnDisplayNames[c.name] ?? c.displayName,
+            displayName: columnDisplayNames[c.name] ?? c.displayName,
         }));
 
         datasetColumns.push({
             name: "taskstatus",
-            displayName: this.columnDisplayNames.taskstatus ?? "Task Status",
+            displayName: columnDisplayNames.taskstatus ?? "Task Status",
             dataType: "SingleLine.Text",
             alias: "taskstatus",
             order: datasetColumns.length + 1,
@@ -51,7 +57,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         datasetColumns.push({
             name: "assignedto",
-            displayName: this.columnDisplayNames.assignedto ?? "Assigned To",
+            displayName: columnDisplayNames.assignedto ?? "Assigned To",
             dataType: "SingleLine.Text",
             alias: "assignedto",
             order: datasetColumns.length + 1,
@@ -59,7 +65,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         datasetColumns.push({
             name: "tasktitle",
-            displayName: this.columnDisplayNames.tasktitle ?? "Task Title",
+            displayName: columnDisplayNames.tasktitle ?? "Task Title",
             dataType: "SingleLine.Text",
             alias: "tasktitle",
             order: datasetColumns.length + 1,
@@ -67,7 +73,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         datasetColumns.push({
             name: "action",
-            displayName: this.columnDisplayNames.action ?? "Action",
+            displayName: columnDisplayNames.action ?? "Action",
             dataType: "SingleLine.Text",
             alias: "action",
             order: datasetColumns.length + 1,
@@ -200,11 +206,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
-        const onUpdateColumnDisplayName = (name: string, value: string): void => {
-            this.columnDisplayNames[name] = value;
-            this.notifyOutputChanged();
-        };
-
         const props: GridProps = {
             datasetColumns,
             records,
@@ -227,7 +228,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchText: this.searchText,
-            onUpdateColumnDisplayName,
         };
 
         return React.createElement(Grid, props);


### PR DESCRIPTION
## Summary
- add `columnDisplayNames` property so column display names can be configured without hardcoding
- use supplied mapping to override dataset column names and remove in-grid editing UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adabe8a1bc832c8518b5e294ff364e