### PR TITLE
Allow column display name overrides via manifest input

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -30,7 +30,7 @@
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
     <!-- Optional mapping of column logical names to display names as JSON -->
-    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.TextArea" usage="input" required="false" />
+    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.TextArea" usage="input" required="false" default-value="{}" />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>
       <code path="index.ts" order="1"/>

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -28,10 +28,10 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const taskIdField = context.parameters.taskIdField.raw ?? "taskid";
         const taskEntity = context.parameters.taskEntity.raw ?? "";
         const navigationTarget = context.parameters.navigationTarget.raw ?? "";
-        const columnDisplayNamesRaw = context.parameters.columnDisplayNames?.raw ?? "";
+        const columnDisplayNamesRaw = context.parameters.columnDisplayNames?.raw?.trim() ?? "{}";
         let columnDisplayNames: Record<string, string>;
         try {
-            columnDisplayNames = columnDisplayNamesRaw ? JSON.parse(columnDisplayNamesRaw) as Record<string, string> : {};
+            columnDisplayNames = JSON.parse(columnDisplayNamesRaw) as Record<string, string>;
         } catch {
             columnDisplayNames = {};
         }


### PR DESCRIPTION
## Summary
- add default column display name mapping input to manifest
- parse and apply JSON mapping for column display names

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb2b950b0832c85fa47c2aff3362d