### PR TITLE
Allow editing of column display names

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -30,7 +30,7 @@
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
     <!-- Optional mapping of column logical names to display names as JSON -->
-    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.TextArea" usage="input" required="false" default-value="{}" />
+    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.Text" usage="input" required="false" default-value="{}" />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>
       <code path="index.ts" order="1"/>


### PR DESCRIPTION
## Summary
- allow column display name mappings to be edited in the property pane by switching to a standard text input

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@fluentui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68adbd5b5c68832c9af9673a9b863bde