### PR TITLE
Disable in-app column renaming and enable property-based display names

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -30,7 +30,7 @@
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
     <!-- Optional mapping of column logical names to display names as JSON -->
-    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.Text" usage="bound" required="false" default-value="{}" />
+    <property name="columnDisplayNames" display-name-key="ColumnDisplayNames" description-key="ColumnDisplayNames description" of-type="SingleLine.Text" usage="input" required="false" default-value="{}" />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>
       <code path="index.ts" order="1"/>

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -49,7 +49,6 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   searchText?: string;
-  onRenameColumn?: (columnKey: string, newName: string) => void;
 }
 
 const defaultTheme = createTheme({
@@ -111,7 +110,6 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     searchText,
-    onRenameColumn,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -168,18 +166,6 @@ export const Grid = React.memo((props: GridProps) => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
-        {onRenameColumn && (
-          <Stack horizontal tokens={{ childrenGap: 8 }} style={{ marginBottom: 16 }}>
-            {columns.map((col) => (
-              <TextField
-                key={col.key}
-                label={col.key}
-                value={col.name}
-                onChange={(_, v) => onRenameColumn(col.key, v ?? '')}
-              />
-            ))}
-          </Stack>
-        )}
         <TextField
           placeholder="Search"
           value={searchText}

--- a/DetailsListVOA/generated/ManifestTypes.ts
+++ b/DetailsListVOA/generated/ManifestTypes.ts
@@ -9,5 +9,4 @@ export interface IInputs {
 
 export interface IOutputs {
     selectedTaskId?: string;
-    columnDisplayNames?: string;
 }

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -206,11 +206,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
-        const onRenameColumn = (name: string, newName: string): void => {
-            this.columnDisplayNames[name] = newName;
-            this.notifyOutputChanged();
-        };
-
         const props: GridProps = {
             datasetColumns,
             records,
@@ -233,7 +228,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchText: this.searchText,
-            onRenameColumn,
         };
 
         return React.createElement(Grid, props);
@@ -242,7 +236,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     public getOutputs(): IOutputs {
         return {
             selectedTaskId: this.selectedTaskId,
-            columnDisplayNames: JSON.stringify(this.columnDisplayNames),
         };
     }
 


### PR DESCRIPTION
## Summary
- remove column header renaming inputs from grid UI
- make column display names configurable through `columnDisplayNames` property
- drop unused `columnDisplayNames` output

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@fluentui/react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68adc40f3e10832cb3df55203359ed10