### PR TITLE
feat: allow editing dataset column names

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -49,6 +49,7 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   searchText?: string;
+  onUpdateColumnDisplayName: (name: string, displayName: string) => void;
 }
 
 const defaultTheme = createTheme({
@@ -110,6 +111,7 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     searchText,
+    onUpdateColumnDisplayName,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -166,6 +168,16 @@ export const Grid = React.memo((props: GridProps) => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
+        <Stack tokens={{ childrenGap: 8 }}>
+          {datasetColumns.map((col) => (
+            <TextField
+              key={col.name}
+              label={`${col.name} Display Name`}
+              value={col.displayName}
+              onChange={(_, v) => onUpdateColumnDisplayName(col.name, v ?? '')}
+            />
+          ))}
+        </Stack>
         <TextField
           placeholder="Search"
           value={searchText}

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -11,6 +11,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     private searchText = "";
     private currentPage = 0;
     private columnDisplayNames: Record<string, string> = {};
+    private lastColumnDisplayNamesRaw = "";
 
     constructor() {
         // Empty
@@ -30,10 +31,13 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const taskEntity = context.parameters.taskEntity.raw ?? "";
         const navigationTarget = context.parameters.navigationTarget.raw ?? "";
         const columnDisplayNamesRaw = context.parameters.columnDisplayNames?.raw?.trim() ?? "{}";
-        try {
-            this.columnDisplayNames = JSON.parse(columnDisplayNamesRaw) as Record<string, string>;
-        } catch {
-            this.columnDisplayNames = {};
+        if (this.lastColumnDisplayNamesRaw !== columnDisplayNamesRaw) {
+            try {
+                this.columnDisplayNames = JSON.parse(columnDisplayNamesRaw) as Record<string, string>;
+            } catch {
+                this.columnDisplayNames = {};
+            }
+            this.lastColumnDisplayNamesRaw = columnDisplayNamesRaw;
         }
 
         const selection: ISelection<IObjectWithKey> = new Selection<IObjectWithKey>({
@@ -206,6 +210,11 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
+        const onUpdateColumnDisplayName = (name: string, value: string): void => {
+            this.columnDisplayNames[name] = value;
+            this.notifyOutputChanged();
+        };
+
         const props: GridProps = {
             datasetColumns,
             records,
@@ -228,6 +237,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchText: this.searchText,
+            onUpdateColumnDisplayName,
         };
 
         return React.createElement(Grid, props);


### PR DESCRIPTION
## Summary
- allow updating dataset column headers through text fields
- keep column display names responsive via update callback

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc66be450832cbf3679bb8fe81a8f