### PR TITLE
Remove column display name editing from grid UI

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -49,7 +49,6 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   searchText?: string;
-  onUpdateColumnDisplayName: (name: string, displayName: string) => void;
 }
 
 const defaultTheme = createTheme({
@@ -111,7 +110,6 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     searchText,
-    onUpdateColumnDisplayName,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -168,16 +166,6 @@ export const Grid = React.memo((props: GridProps) => {
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
-        <Stack tokens={{ childrenGap: 8 }}>
-          {datasetColumns.map((col) => (
-            <TextField
-              key={col.name}
-              label={`${col.name} Display Name`}
-              value={col.displayName}
-              onChange={(_, v) => onUpdateColumnDisplayName(col.name, v ?? '')}
-            />
-          ))}
-        </Stack>
         <TextField
           placeholder="Search"
           value={searchText}

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -210,11 +210,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
-        const onUpdateColumnDisplayName = (name: string, value: string): void => {
-            this.columnDisplayNames[name] = value;
-            this.notifyOutputChanged();
-        };
-
         const props: GridProps = {
             datasetColumns,
             records,
@@ -237,7 +232,6 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchText: this.searchText,
-            onUpdateColumnDisplayName,
         };
 
         return React.createElement(Grid, props);


### PR DESCRIPTION
## Summary
- remove text fields that allowed editing column display names directly in the grid
- clean up grid props by dropping unused `onUpdateColumnDisplayName`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@fluentui/react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68adc8f586c8832cbd55026133d741a4