### PR TITLE
Enable dataset sorting and column reordering

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -3,6 +3,7 @@ import {
   CheckboxVisibility,
   createTheme,
   IColumn,
+  IColumnReorderOptions,
   IDetailsList,
   IObjectWithKey,
   IRefObject,
@@ -109,13 +110,15 @@ export const Grid = React.memo((props: GridProps) => {
     totalPages,
     canNext,
     canPrev,
-    searchText,
+  searchText,
   } = props;
 
   const theme = useTheme(themeJSON);
 
-  const columns = React.useMemo<IColumn[]>(
-    () =>
+  const [columns, setColumns] = React.useState<IColumn[]>([]);
+
+  React.useEffect(() => {
+    setColumns(
       datasetColumns.map((c) => {
         const sort = sorting.find((s) => s.name === c.name);
         const visualSize =
@@ -132,7 +135,23 @@ export const Grid = React.memo((props: GridProps) => {
           isSortedDescending: sort ? Number(sort.sortDirection) === 1 : undefined,
         } as IColumn;
       }),
-    [datasetColumns, sorting],
+    );
+  }, [datasetColumns, sorting]);
+
+  const handleColumnReorder = React.useCallback((draggedIndex: number, targetIndex: number) => {
+    setColumns((prev) => {
+      const newCols = [...prev];
+      const [moved] = newCols.splice(draggedIndex, 1);
+      newCols.splice(targetIndex, 0, moved);
+      return newCols;
+    });
+  }, []);
+
+  const columnReorderOptions = React.useMemo<IColumnReorderOptions>(
+    () => ({
+      handleColumnReorder,
+    }),
+    [handleColumnReorder],
   );
 
   const items = React.useMemo<DataSet[]>(() => {
@@ -183,6 +202,7 @@ export const Grid = React.memo((props: GridProps) => {
           checkboxVisibility={CheckboxVisibility.hidden}
           onColumnHeaderClick={onColumnHeaderClick}
           onItemInvoked={onItemInvoked}
+          columnReorderOptions={columnReorderOptions}
           compact={compact}
           isHeaderVisible={isHeaderVisible}
         />

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -212,6 +212,26 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
+        const onSort = (name: string, desc: boolean): void => {
+            const sortDirection = desc ? 1 : 0;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const sorting = dataset.sorting as unknown as any;
+            if (sorting) {
+                if (typeof sorting.setSort === "function") {
+                    sorting.setSort(name, sortDirection);
+                } else if (typeof sorting.sortByName === "function") {
+                    sorting.sortByName(name, sortDirection);
+                } else if (typeof sorting.addSort === "function") {
+                    sorting.clear?.();
+                    sorting.addSort(name, sortDirection);
+                } else {
+                    sorting.length = 0;
+                    sorting.push({ name, sortDirection });
+                }
+            }
+            dataset.refresh();
+        };
+
         const props: GridProps = {
             datasetColumns,
             records,
@@ -221,8 +241,8 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             selectionType: SelectionMode.none,
             selection,
             onNavigate,
-            onSort: () => undefined,
-            sorting: [],
+            onSort,
+            sorting: dataset.sorting,
             componentRef,
             resources: context.resources,
             onSearch,


### PR DESCRIPTION
## Summary
- support dataset-driven sorting in Grid
- allow Fluent UI DetailsList columns to be reordered

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68add959f8b8832c8f9afece6c2e2dcb