### PR TITLE
Guard grid column sorting and image widths

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -120,7 +120,7 @@ export const Grid = React.memo((props: GridProps) => {
   React.useEffect(() => {
     setColumns(
       datasetColumns.map((c) => {
-        const sort = sorting.find((s) => s.name === c.name);
+        const sort = sorting?.find((s) => s.name === c.name);
         const visualSize =
           typeof c.visualSizeFactor === 'number' && !isNaN(c.visualSizeFactor)
             ? c.visualSizeFactor
@@ -220,7 +220,7 @@ export const Grid = React.memo((props: GridProps) => {
           />
           {Array.from({ length: totalPages }, (_, i) => (
             <Text
-              key={i}
+              key={`page-${i}`}
               style={{
                 cursor: 'pointer',
                 fontWeight: i === currentPage ? 600 : undefined,

--- a/DetailsListVOA/GridCell.tsx
+++ b/DetailsListVOA/GridCell.tsx
@@ -267,7 +267,10 @@ function getImageTag(imageData: string, column: IGridColumn, iconColor: string) 
     let buttonContent: JSX.Element | null = null;
     const iconName = imageData.substring('icon:'.length);
 
-    const validWidth = typeof column.imageWidth === 'number' ? column.imageWidth : undefined;
+    const validWidth =
+        typeof column.imageWidth === 'number' && !isNaN(column.imageWidth)
+            ? column.imageWidth
+            : undefined;
 
     if (imageData.startsWith('icon:')) {
         const fontSize = validWidth ?? 18;


### PR DESCRIPTION
## Summary
- avoid undefined access when detecting column sorting
- ensure image width is a valid number to prevent NaN warnings
- use stable keys for page links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TS errors in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68addba6173c832cbcafe2487ce05cff