### PR TITLE
Parse numeric widths from metadata

### DIFF
--- a/DetailsListVOA/Component.types.ts
+++ b/DetailsListVOA/Component.types.ts
@@ -20,7 +20,7 @@ export interface IGridColumn extends IColumn {
     hideWhenBlank?: boolean;
     ariaTextColumn?: string;
     cellActionDisabledColumn?: string;
-    imageWidth?: string;
+    imageWidth?: number;
     imagePadding?: number;
     verticalAligned?: string;
     horizontalAligned?: string;

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -76,12 +76,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             const columnArray = JSON.parse(columnMetadataRaw) as Record<string, unknown>[];
             gridColumns = columnArray.map((c, i) => {
                 const name = typeof c.ColName === "string" ? c.ColName : `col${i}`;
-                const width =
-                    typeof c.ColWidth === "number"
-                        ? c.ColWidth
-                        : typeof c.ColWidth === "string"
-                            ? parseFloat(c.ColWidth)
-                            : undefined;
+                const width = parseNumber(c.ColWidth);
                 const displayNameOverride = this.columnDisplayNames[name];
                 const finalName =
                     (typeof displayNameOverride === "string" ? displayNameOverride : undefined) ??
@@ -114,7 +109,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
                         typeof c.ColCellActionDisabledColumn === "string"
                             ? c.ColCellActionDisabledColumn
                             : undefined,
-                    imageWidth: typeof c.ColImageWidth === "string" ? c.ColImageWidth : undefined,
+                    imageWidth: parseNumber(c.ColImageWidth),
                     imagePadding: parseNumber(c.ColImagePadding),
                     verticalAligned: typeof c.ColVerticalAlign === "string" ? c.ColVerticalAlign : undefined,
                     horizontalAligned: typeof c.ColHorizontalAlign === "string" ? c.ColHorizontalAlign : undefined,


### PR DESCRIPTION
## Summary
- parse `ColImageWidth` to a number when building column metadata
- align `IGridColumn.imageWidth` type with numeric values
- guard column widths from invalid metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0ce9fe84832ca1c9e3d87269d6d7