### PR TITLE
Add dynamic column metadata support

### DIFF
--- a/DetailsListVOA/Component.types.ts
+++ b/DetailsListVOA/Component.types.ts
@@ -1,6 +1,8 @@
 import { IColumn } from '@fluentui/react';
 
 export interface IGridColumn extends IColumn {
+    key: string;
+    fieldName: string;
     isBold?: boolean;
     tagColor?: string;
     tagBorderColor?: string;

--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -39,6 +39,16 @@
       required="false"
       default-value="{}"
     />
+    <!-- Column configuration supplied as a JSON array -->
+    <property
+      name="columnMetadata"
+      display-name-key="Column Metadata"
+      description-key="JSON array describing grid columns. Example: [{&quot;ColName&quot;:&quot;taskstatus&quot;,&quot;ColDisplayName&quot;:&quot;Task Status&quot;,&quot;ColWidth&quot;:100}]"
+      of-type="SingleLine.TextArea"
+      usage="input"
+      required="false"
+      default-value="[{&quot;ColName&quot;:&quot;taskstatus&quot;,&quot;ColDisplayName&quot;:&quot;Task Status&quot;,&quot;ColWidth&quot;:100},{&quot;ColName&quot;:&quot;assignedto&quot;,&quot;ColDisplayName&quot;:&quot;Assigned To&quot;,&quot;ColWidth&quot;:100},{&quot;ColName&quot;:&quot;tasktitle&quot;,&quot;ColDisplayName&quot;:&quot;Task Title&quot;,&quot;ColWidth&quot;:100},{&quot;ColName&quot;:&quot;action&quot;,&quot;ColDisplayName&quot;:&quot;Action&quot;,&quot;ColWidth&quot;:100}]"
+    />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>
       <code path="index.ts" order="1"/>

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -20,12 +20,14 @@ import {
 import * as React from 'react';
 import { NoFields } from './NoFields';
 import { RecordsColumns } from './ManifestConstants';
+import { GridCell } from './GridCell';
+import { IGridColumn } from './Component.types';
 
 type DataSet = ComponentFramework.PropertyHelper.DataSetApi.EntityRecord & IObjectWithKey;
 
 export interface GridProps {
   height?: number;
-  datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[];
+  columns: IGridColumn[];
   records: Record<string, ComponentFramework.PropertyHelper.DataSetApi.EntityRecord>;
   sortedRecordIds: string[];
   shimmer: boolean;
@@ -85,7 +87,7 @@ export function getRecordKey(record: ComponentFramework.PropertyHelper.DataSetAp
 
 export const Grid = React.memo((props: GridProps) => {
   const {
-    datasetColumns,
+    columns: inputColumns,
     records,
     sortedRecordIds,
     shimmer,
@@ -115,31 +117,23 @@ export const Grid = React.memo((props: GridProps) => {
 
   const theme = useTheme(themeJSON);
 
-  const [columns, setColumns] = React.useState<IColumn[]>([]);
+  const [displayColumns, setDisplayColumns] = React.useState<IGridColumn[]>([]);
 
   React.useEffect(() => {
-    setColumns(
-      datasetColumns.map((c) => {
-        const sort = sorting?.find((s) => s.name === c.name);
-        const visualSize =
-          typeof c.visualSizeFactor === 'number' && !isNaN(c.visualSizeFactor)
-            ? c.visualSizeFactor
-            : 100;
+    setDisplayColumns(
+      inputColumns.map((c) => {
+        const sort = sorting?.find((s) => s.name === c.fieldName);
         return {
-          key: c.name,
-          name: c.displayName,
-          fieldName: c.name,
-          minWidth: visualSize,
-          isResizable: true,
+          ...c,
           isSorted: !!sort,
           isSortedDescending: sort ? Number(sort.sortDirection) === 1 : undefined,
-        } as IColumn;
+        } as IGridColumn;
       }),
     );
-  }, [datasetColumns, sorting]);
+  }, [inputColumns, sorting]);
 
   const handleColumnReorder = React.useCallback((draggedIndex: number, targetIndex: number) => {
-    setColumns((prev) => {
+    setDisplayColumns((prev) => {
       const newCols = [...prev];
       const [moved] = newCols.splice(draggedIndex, 1);
       newCols.splice(targetIndex, 0, moved);
@@ -178,9 +172,18 @@ export const Grid = React.memo((props: GridProps) => {
     [onSort],
   );
 
-  if (columnDatasetNotDefined || datasetColumns.length === 0) {
+  if (columnDatasetNotDefined || inputColumns.length === 0) {
     return <NoFields resources={resources} />;
   }
+
+  const onRenderItemColumn = React.useCallback(
+    (
+      item?: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord,
+      index?: number,
+      column?: IColumn,
+    ) => <GridCell item={item ?? ({} as Record<string, unknown>)} index={index} column={column} onCellAction={onNavigate} />,
+    [onNavigate],
+  );
 
   return (
     <ThemeProvider theme={theme}>
@@ -194,7 +197,7 @@ export const Grid = React.memo((props: GridProps) => {
         <ShimmeredDetailsList
           componentRef={componentRef}
           items={items}
-          columns={columns}
+          columns={displayColumns}
           setKey="grid"
           enableShimmer={itemsLoading || shimmer}
           selectionMode={selectionType}
@@ -205,6 +208,7 @@ export const Grid = React.memo((props: GridProps) => {
           columnReorderOptions={columnReorderOptions}
           compact={compact}
           isHeaderVisible={isHeaderVisible}
+          onRenderItemColumn={onRenderItemColumn}
         />
         <Stack
           horizontal

--- a/DetailsListVOA/generated/ManifestTypes.d.ts
+++ b/DetailsListVOA/generated/ManifestTypes.d.ts
@@ -1,12 +1,17 @@
+/*
+*This is auto generated from the ControlManifest.Input.xml file
+*/
+
+// Define IInputs and IOutputs Type. They should match with ControlManifest.
 export interface IInputs {
-    revalSalesDataset: ComponentFramework.PropertyTypes.DataSet;
     taskIdField: ComponentFramework.PropertyTypes.StringProperty;
     taskEntity: ComponentFramework.PropertyTypes.StringProperty;
     navigationTarget: ComponentFramework.PropertyTypes.StringProperty;
     pageSize: ComponentFramework.PropertyTypes.WholeNumberProperty;
     columnDisplayNames: ComponentFramework.PropertyTypes.StringProperty;
+    columnMetadata: ComponentFramework.PropertyTypes.StringProperty;
+    revalSalesDataset: ComponentFramework.PropertyTypes.DataSet;
 }
-
 export interface IOutputs {
     selectedTaskId?: string;
 }

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -1,8 +1,9 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
-import { IInputs, IOutputs } from "./generated/ManifestTypes";
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument */
+import type { IInputs, IOutputs } from "./generated/ManifestTypes";
 import { Grid, GridProps } from "./Grid";
+import { IGridColumn } from "./Component.types";
 import * as React from "react";
-import { IDetailsList, ISelection, Selection, SelectionMode, IObjectWithKey } from '@fluentui/react';
+import { IDetailsList, ISelection, Selection, SelectionMode, IObjectWithKey, IColumn } from '@fluentui/react';
 
 export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, IOutputs> {
     private notifyOutputChanged: () => void;
@@ -30,6 +31,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const taskIdField = context.parameters.taskIdField.raw ?? "taskid";
         const taskEntity = context.parameters.taskEntity.raw ?? "";
         const navigationTarget = context.parameters.navigationTarget.raw ?? "";
+
         // Column display name overrides are provided as JSON in the columnDisplayNames property.
         // Parse the property whenever it changes so makers can customize labels.
         const columnDisplayNamesRaw = context.parameters.columnDisplayNames?.raw?.trim() ?? "{}";
@@ -42,49 +44,127 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             this.lastColumnDisplayNamesRaw = columnDisplayNamesRaw;
         }
 
+        // Column metadata is supplied as a JSON array. Each entry describes a column's
+        // configuration using the schema defined in the README.
+        const columnMetadataRaw = context.parameters.columnMetadata?.raw?.trim() ?? "[]";
+
+        const parseBool = (value: unknown): boolean | undefined => {
+            if (typeof value === "boolean") {
+                return value;
+            }
+            if (typeof value === "string") {
+                return value.toLowerCase() === "true";
+            }
+            return undefined;
+        };
+        const parseNumber = (value: unknown): number | undefined => {
+            if (typeof value === "number") {
+                return isNaN(value) ? undefined : value;
+            }
+            if (typeof value === "string") {
+                const n = parseFloat(value);
+                return isNaN(n) ? undefined : n;
+            }
+            return undefined;
+        };
+
+        let gridColumns: IGridColumn[] = [];
+        try {
+            const columnArray = JSON.parse(columnMetadataRaw) as Record<string, unknown>[];
+            gridColumns = columnArray.map((c, i) => {
+                const name = typeof c.ColName === "string" ? c.ColName : `col${i}`;
+                const width =
+                    typeof c.ColWidth === "number"
+                        ? c.ColWidth
+                        : typeof c.ColWidth === "string"
+                            ? parseFloat(c.ColWidth)
+                            : undefined;
+                const displayNameOverride = this.columnDisplayNames[name];
+                const finalName =
+                    (typeof displayNameOverride === "string" ? displayNameOverride : undefined) ??
+                    (typeof c.ColDisplayName === "string" ? c.ColDisplayName : undefined) ??
+                    name;
+                return {
+                    key: name,
+                    fieldName: name,
+                    name: finalName,
+                    minWidth: width,
+                    maxWidth: width,
+                    cellType: typeof c.ColCellType === "string" ? c.ColCellType : undefined,
+                    tagColor: typeof c.ColTagColorColumn === "string" ? c.ColTagColorColumn : undefined,
+                    tagBorderColor: typeof c.ColTagBorderColorColumn === "string" ? c.ColTagBorderColorColumn : undefined,
+                    isBold: parseBool(c.ColIsBold),
+                    isMultiline: parseBool(c.ColMultiLine),
+                    isResizable: parseBool(c.ColResizable) ?? true,
+                    headerPaddingLeft: parseNumber(c.ColHeaderPaddingLeft),
+                    showAsSubTextOf: typeof c.ColShowAsSubTextOf === "string" ? c.ColShowAsSubTextOf : undefined,
+                    paddingTop: parseNumber(c.ColPaddingTop),
+                    paddingLeft: parseNumber(c.ColPaddingLeft),
+                    isLabelAbove: parseBool(c.ColLabelAbove),
+                    multiValuesDelimiter: typeof c.ColMultiValueDelimiter === "string" ? c.ColMultiValueDelimiter : undefined,
+                    firstMultiValueBold: parseBool(c.ColFirstMultiValueBold),
+                    inlineLabel: typeof c.ColInlineLabel === "string" ? c.ColInlineLabel : undefined,
+                    hideWhenBlank: parseBool(c.ColHideWhenBlank),
+                    subTextRow: parseNumber(c.ColSubTextRow),
+                    ariaTextColumn: typeof c.ColAriaTextColumn === "string" ? c.ColAriaTextColumn : undefined,
+                    cellActionDisabledColumn:
+                        typeof c.ColCellActionDisabledColumn === "string"
+                            ? c.ColCellActionDisabledColumn
+                            : undefined,
+                    imageWidth: typeof c.ColImageWidth === "string" ? c.ColImageWidth : undefined,
+                    imagePadding: parseNumber(c.ColImagePadding),
+                    verticalAligned: typeof c.ColVerticalAlign === "string" ? c.ColVerticalAlign : undefined,
+                    horizontalAligned: typeof c.ColHorizontalAlign === "string" ? c.ColHorizontalAlign : undefined,
+                    childColumns: [],
+                } as IGridColumn;
+            });
+        } catch {
+            gridColumns = [];
+        }
+
+        const ensureColumn = (col: IGridColumn): void => {
+            if (!gridColumns.some((c) => c.fieldName === col.fieldName)) {
+                gridColumns.push(col);
+            }
+        };
+
+        ensureColumn({
+            key: "taskstatus",
+            fieldName: "taskstatus",
+            name: this.columnDisplayNames.taskstatus ?? "Task Status",
+            minWidth: 100,
+            maxWidth: 100,
+            childColumns: [],
+        } as IGridColumn);
+        ensureColumn({
+            key: "assignedto",
+            fieldName: "assignedto",
+            name: this.columnDisplayNames.assignedto ?? "Assigned To",
+            minWidth: 100,
+            maxWidth: 100,
+            childColumns: [],
+        } as IGridColumn);
+        ensureColumn({
+            key: "tasktitle",
+            fieldName: "tasktitle",
+            name: this.columnDisplayNames.tasktitle ?? "Task Title",
+            minWidth: 100,
+            maxWidth: 100,
+            childColumns: [],
+        } as IGridColumn);
+        ensureColumn({
+            key: "action",
+            fieldName: "action",
+            name: this.columnDisplayNames.action ?? "Action",
+            minWidth: 100,
+            maxWidth: 100,
+            childColumns: [],
+        } as IGridColumn);
         const selection: ISelection<IObjectWithKey> = new Selection<IObjectWithKey>({
             getKey: (item: IObjectWithKey) =>
                 (item as unknown as ComponentFramework.PropertyHelper.DataSetApi.EntityRecord).getRecordId(),
         });
         const componentRef = React.createRef<IDetailsList>();
-
-        const datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[] = dataset.columns.map((c) => ({
-            ...c,
-            displayName: this.columnDisplayNames[c.name] ?? c.displayName,
-        }));
-
-        datasetColumns.push({
-            name: "taskstatus",
-            displayName: this.columnDisplayNames.taskstatus ?? "Task Status",
-            dataType: "SingleLine.Text",
-            alias: "taskstatus",
-            order: datasetColumns.length + 1,
-            visualSizeFactor: 100,
-        } as ComponentFramework.PropertyHelper.DataSetApi.Column);
-        datasetColumns.push({
-            name: "assignedto",
-            displayName: this.columnDisplayNames.assignedto ?? "Assigned To",
-            dataType: "SingleLine.Text",
-            alias: "assignedto",
-            order: datasetColumns.length + 1,
-            visualSizeFactor: 100,
-        } as ComponentFramework.PropertyHelper.DataSetApi.Column);
-        datasetColumns.push({
-            name: "tasktitle",
-            displayName: this.columnDisplayNames.tasktitle ?? "Task Title",
-            dataType: "SingleLine.Text",
-            alias: "tasktitle",
-            order: datasetColumns.length + 1,
-            visualSizeFactor: 100,
-        } as ComponentFramework.PropertyHelper.DataSetApi.Column);
-        datasetColumns.push({
-            name: "action",
-            displayName: this.columnDisplayNames.action ?? "Action",
-            dataType: "SingleLine.Text",
-            alias: "action",
-            order: datasetColumns.length + 1,
-            visualSizeFactor: 100,
-        } as ComponentFramework.PropertyHelper.DataSetApi.Column);
 
         const records: Record<string, ComponentFramework.PropertyHelper.DataSetApi.EntityRecord> = {};
         const allIds: string[] = [];
@@ -145,8 +225,9 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             const search = this.searchText.toLowerCase();
             filteredIds = filteredIds.filter((id) => {
                 const rec = records[id] as unknown as Record<string, unknown>;
-                return datasetColumns.some((c) => {
-                    const val = rec[c.name];
+                return gridColumns.some((c) => {
+                    const field = (c as IColumn).fieldName ?? c.key;
+                    const val = field ? rec[field] : undefined;
                     return typeof val === "string" && val.toLowerCase().includes(search);
                 });
             });
@@ -233,7 +314,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         };
 
         const props: GridProps = {
-            datasetColumns,
+            columns: gridColumns,
             records,
             sortedRecordIds: pageIds,
             shimmer: dataset.loading,
@@ -245,6 +326,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             sorting: dataset.sorting,
             componentRef,
             resources: context.resources,
+            columnDatasetNotDefined: gridColumns.length === 0,
             onSearch,
             onNextPage,
             onPrevPage,

--- a/README.md
+++ b/README.md
@@ -13,3 +13,38 @@ Example:
 ```
 
 The control parses this mapping and applies the custom names to the corresponding columns at runtime. Invalid JSON is ignored and the dataset's default display names are used instead.
+
+## Column Metadata
+
+The grid's columns are defined by a JSON array. Each object in the array describes a column using the following schema:
+
+```json
+[
+  {
+    "ColName": "status",
+    "ColDisplayName": "Status",
+    "ColWidth": 120,
+    "ColCellType": "tag",
+    "ColTagColorColumn": "statusColor",
+    "ColTagBorderColorColumn": "statusBorder"
+  }
+]
+```
+
+**Required properties**
+
+- `ColName`: logical name for the column. This becomes the column's key and field name.
+- `ColDisplayName`: header text shown in the grid.
+- `ColWidth`: numeric width in pixels applied to `minWidth` and `maxWidth`.
+
+**Optional properties**
+
+Additional keys map to fields on the `IGridColumn` type to control behaviour:
+
+- `ColCellType` – renders specialised cells such as `tag`, `link`, or `image`.
+- `ColTagColorColumn` and `ColTagBorderColorColumn` – supply colours for tag-based cells.
+- Fields like `ColIsBold`, `ColLabelAbove`, `ColMultiLine`, etc. correspond to properties on `IGridColumn`.
+
+Unsupported keys (for example `ColTooltipField`) are ignored if present.
+
+The **Column Metadata** property is pre-populated with sample definitions for the core `taskstatus`, `assignedto`, `tasktitle`, and `action` columns. Makers can modify or extend this array to configure additional columns.


### PR DESCRIPTION
## Summary
- parse column metadata JSON into IGridColumn definitions and use them in the grid
- render grid cells with GridCell for custom types
- document column metadata JSON schema
- expose columnMetadata property in manifest with sample defaults

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade6206b40832c88209b22dcefc43a