### PR TITLE
feat: flag mismatched column config entries

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -16,6 +16,8 @@ import {
   Stack,
   Text,
   DefaultButton,
+  MessageBar,
+  MessageBarType,
 } from '@fluentui/react';
 import * as React from 'react';
 import { NoFields } from './NoFields';
@@ -208,13 +210,18 @@ export const Grid = React.memo((props: GridProps) => {
     [onSort],
   );
 
-  if (columnDatasetNotDefined || datasetColumns.length === 0) {
+  if (datasetColumns.length === 0) {
     return <NoFields resources={resources} />;
   }
 
   return (
     <ThemeProvider theme={theme}>
       <div style={{ height }}>
+        {columnDatasetNotDefined && (
+          <MessageBar messageBarType={MessageBarType.error} style={{ marginBottom: 16 }}>
+            One or more column configurations reference fields that do not exist in the dataset.
+          </MessageBar>
+        )}
         <TextField
           placeholder="Search"
           value={searchText}

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -105,6 +105,11 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             visualSizeFactor: 100,
         } as ComponentFramework.PropertyHelper.DataSetApi.Column);
 
+        const columnNamesSet = new Set(datasetColumns.map((c) => c.name));
+        const columnDatasetNotDefined = Object.keys(this.columnConfigs).some(
+            (name) => !columnNamesSet.has(name),
+        );
+
         const records: Record<string, ComponentFramework.PropertyHelper.DataSetApi.EntityRecord> = {};
         const allIds: string[] = [];
 
@@ -265,6 +270,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             sorting: dataset.sorting,
             componentRef,
             resources: context.resources,
+            columnDatasetNotDefined,
             onSearch,
             onNextPage,
             onPrevPage,


### PR DESCRIPTION
## Summary
- warn when column configuration names do not exist in dataset
- surface warning message in grid for unknown column configuration fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae3af30024832cba54d9d7d83586d2