### PR TITLE
Render tag cells with custom styling and sorting

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -54,10 +54,7 @@
       <code path="index.ts" order="1"/>
       <platform-library name="React" version="16.14.0" />
       <platform-library name="Fluent" version="9.46.2" />
-      <!-- UNCOMMENT TO ADD MORE RESOURCES
       <css path="css/DetailsListVOA.css" order="1" />
-      <resx path="strings/DetailsListVOA.1033.resx" version="1.0.0" />
-      -->
     </resources>
     <!-- UNCOMMENT TO ENABLE THE SPECIFIED API
     <feature-usage>

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -25,6 +25,8 @@ import * as React from 'react';
 import { NoFields } from './NoFields';
 import { RecordsColumns } from './ManifestConstants';
 import { IGridColumn, ColumnConfig } from './Component.types';
+import { GridCell } from './GridCell';
+import { ClassNames } from './Grid.styles';
 
 type DataSet = ComponentFramework.PropertyHelper.DataSetApi.EntityRecord & IObjectWithKey;
 
@@ -137,6 +139,7 @@ export const Grid = React.memo((props: GridProps) => {
             ? c.visualSizeFactor
             : 100;
         const width = typeof cfg.ColWidth === 'number' ? cfg.ColWidth : visualSize;
+        const cellType = cfg.ColCellType?.toLowerCase();
         const col: IGridColumn = {
           key: c.name,
           name: cfg.ColDisplayName ?? c.displayName,
@@ -173,10 +176,15 @@ export const Grid = React.memo((props: GridProps) => {
           sortBy: cfg.ColSortBy,
           childColumns: [],
         };
+        if (cellType === 'tag' || cellType === 'indicatortag') {
+          col.onRender = (item, _, column) => (
+            <GridCell item={item} column={column} onCellAction={(i) => onNavigate(i)} />
+          );
+        }
         return col;
       }),
     );
-  }, [datasetColumns, sorting, columnConfigs]);
+  }, [datasetColumns, sorting, columnConfigs, onNavigate]);
 
   const handleColumnReorder = React.useCallback((draggedIndex: number, targetIndex: number) => {
     setColumns((prev) => {
@@ -244,6 +252,7 @@ export const Grid = React.memo((props: GridProps) => {
           style={{ marginBottom: 16 }}
         />
         <ShimmeredDetailsList
+          className={ClassNames.PowerCATFluentDetailsList}
           componentRef={componentRef}
           items={items}
           columns={columns}

--- a/DetailsListVOA/css/DetailsListVOA.css
+++ b/DetailsListVOA/css/DetailsListVOA.css
@@ -1,0 +1,42 @@
+.PowerCATFluentDetailsList .status-tag:after {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #5D656E;
+}
+
+.PowerCATFluentDetailsList .status-tag {
+  line-height: 26px;
+  position: relative;
+  padding: 4px 8px 4px 20px;
+  background: #FFFFFF;
+  border-radius: 2px;
+  border: 1px solid #CAD0D5;
+  font-size: 12px;
+  font-weight: bold;
+  color: #212A35;
+  overflow: hidden;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  box-sizing: border-box;
+}
+
+.PowerCATFluentDetailsList .text-tag {
+  line-height: 26px;
+  position: relative;
+  padding: 4px 8px;
+  border-radius: 2px;
+  border-width: 1px;
+  border-style: solid;
+  font-size: 12px;
+  font-weight: 600;
+  color: #212A35;
+  overflow: hidden;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- use GridCell renderer for tag and indicatorTag columns
- add CSS for tag styles and include it via manifest
- mark DetailsList with component class for styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae5666a85c832cb2e56c3ba35223a0