### PR TITLE
Add dynamic filter bar to grid view

### DIFF
--- a/DetailsListVOA/Filters.ts
+++ b/DetailsListVOA/Filters.ts
@@ -1,0 +1,58 @@
+export type SearchByOption = 'uprn' | 'taskId' | 'address' | 'manualCheck' | 'postcode';
+
+export type ManualCheckFilter = 'yes' | 'no' | 'all';
+
+export interface GridFilterState {
+  searchBy: SearchByOption;
+  uprn?: string;
+  taskId?: string;
+  buildingNameNumber?: string;
+  street?: string;
+  townCity?: string;
+  postcode?: string;
+  manualCheck?: ManualCheckFilter;
+}
+
+export const createDefaultGridFilters = (): GridFilterState => ({
+  searchBy: 'address',
+  manualCheck: 'all',
+});
+
+export const sanitizeFilters = (filters: GridFilterState): GridFilterState => {
+  const sanitized: GridFilterState = {
+    searchBy: filters.searchBy,
+    manualCheck: filters.manualCheck ?? 'all',
+  };
+
+  if (filters.uprn) {
+    const digits = filters.uprn.replace(/\D/g, '');
+    sanitized.uprn = digits.length > 0 ? digits : undefined;
+  }
+
+  if (filters.taskId) {
+    const trimmed = filters.taskId.trim();
+    sanitized.taskId = trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (filters.buildingNameNumber) {
+    const trimmed = filters.buildingNameNumber.trim();
+    sanitized.buildingNameNumber = trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (filters.street) {
+    const trimmed = filters.street.trim();
+    sanitized.street = trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (filters.townCity) {
+    const trimmed = filters.townCity.trim();
+    sanitized.townCity = trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (filters.postcode) {
+    const trimmed = filters.postcode.trim().toUpperCase();
+    sanitized.postcode = trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  return sanitized;
+};

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -13,6 +13,7 @@ import {
   IRefObject,
   ISelection,
   IPartialTheme,
+  IDropdownOption,
   PrimaryButton,
   SelectionMode,
   ShimmeredDetailsList,
@@ -24,6 +25,10 @@ import {
   DefaultButton,
   MessageBar,
   MessageBarType,
+  Dropdown,
+  Spinner,
+  SpinnerSize,
+  Link,
 } from '@fluentui/react';
 import * as React from 'react';
 import { NoFields } from './NoFields';
@@ -31,6 +36,13 @@ import { RecordsColumns } from './ManifestConstants';
 import { IGridColumn, ColumnConfig } from './Component.types';
 import { GridCell } from './GridCell';
 import { ClassNames } from './Grid.styles';
+import {
+  GridFilterState,
+  createDefaultGridFilters,
+  sanitizeFilters,
+  SearchByOption,
+  ManualCheckFilter,
+} from './Filters';
 
 type DataSet = ComponentFramework.PropertyHelper.DataSetApi.EntityRecord & IObjectWithKey;
 
@@ -53,7 +65,7 @@ export interface GridProps {
   isHeaderVisible?: boolean;
   resources: ComponentFramework.Resources;
   columnDatasetNotDefined?: boolean;
-  onSearch: (text: string) => void;
+  onSearch: (filters: GridFilterState) => void;
   onNextPage: () => void;
   onPrevPage: () => void;
   onSetPage: (page: number) => void;
@@ -62,7 +74,7 @@ export interface GridProps {
   canNext: boolean;
   canPrev: boolean;
   overlayOnSort?: boolean;
-  searchText?: string;
+  searchFilters: GridFilterState;
 }
 
 const defaultTheme = createTheme({
@@ -125,7 +137,7 @@ export const Grid = React.memo((props: GridProps) => {
     canNext,
     canPrev,
     overlayOnSort,
-  searchText,
+    searchFilters,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -138,6 +150,155 @@ export const Grid = React.memo((props: GridProps) => {
     column: IGridColumn;
   }>();
   const [menuFilterValue, setMenuFilterValue] = React.useState('');
+  const [filters, setFilters] = React.useState<GridFilterState>(searchFilters);
+
+  React.useEffect(() => {
+    setFilters(searchFilters);
+  }, [searchFilters]);
+
+  const searchByOptions = React.useMemo<IDropdownOption[]>(
+    () => [
+      { key: 'uprn', text: 'UPRN' },
+      { key: 'taskId', text: 'Task ID' },
+      { key: 'address', text: 'Address' },
+      { key: 'manualCheck', text: 'Manual Check' },
+      { key: 'postcode', text: 'Postcode' },
+    ],
+    [],
+  );
+
+  const manualCheckOptions = React.useMemo<IDropdownOption[]>(
+    () => [
+      { key: 'all', text: 'All' },
+      { key: 'yes', text: 'Yes' },
+      { key: 'no', text: 'No' },
+    ],
+    [],
+  );
+
+  const onFieldEnter = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLElement>) => {
+      if (ev.key === 'Enter') {
+        ev.preventDefault();
+        const sanitized = sanitizeFilters(filters);
+        const uprnInvalid = sanitized.searchBy === 'uprn' && !!sanitized.uprn && (sanitized.uprn.length < 8 || sanitized.uprn.length > 10);
+        if (!uprnInvalid) {
+          setFilters(sanitized);
+          onSearch(sanitized);
+        }
+      }
+    },
+    [filters, onSearch],
+  );
+
+  const updateFilters = React.useCallback(
+    (key: keyof GridFilterState, value: GridFilterState[keyof GridFilterState]) => {
+      setFilters((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const onSearchByChange = React.useCallback(
+    (_: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
+      if (!option) {
+        return;
+      }
+      const selected = option.key as SearchByOption;
+      setFilters((prev) => ({
+        ...prev,
+        searchBy: selected,
+        manualCheck: prev.manualCheck ?? 'all',
+      }));
+    },
+    [],
+  );
+
+  const onManualCheckChange = React.useCallback(
+    (_: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
+      if (!option) {
+        return;
+      }
+      updateFilters('manualCheck', option.key as ManualCheckFilter);
+    },
+    [updateFilters],
+  );
+
+  const onUprnChange = React.useCallback(
+    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
+      const digits = (value ?? '').replace(/\D/g, '');
+      updateFilters('uprn', digits);
+    },
+    [updateFilters],
+  );
+
+  const onTaskIdChange = React.useCallback(
+    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
+      updateFilters('taskId', value ?? '');
+    },
+    [updateFilters],
+  );
+
+  const onBuildingNameChange = React.useCallback(
+    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
+      updateFilters('buildingNameNumber', value ?? '');
+    },
+    [updateFilters],
+  );
+
+  const onStreetChange = React.useCallback(
+    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
+      updateFilters('street', value ?? '');
+    },
+    [updateFilters],
+  );
+
+  const onTownChange = React.useCallback(
+    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
+      updateFilters('townCity', value ?? '');
+    },
+    [updateFilters],
+  );
+
+  const onPostcodeChange = React.useCallback(
+    (_: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value?: string) => {
+      updateFilters('postcode', (value ?? '').toUpperCase());
+    },
+    [updateFilters],
+  );
+
+  const uprnError = React.useMemo(() => {
+    if (filters.searchBy !== 'uprn' || !filters.uprn || filters.uprn.length === 0) {
+      return undefined;
+    }
+    if (filters.uprn.length >= 8 && filters.uprn.length <= 10) {
+      return undefined;
+    }
+    return 'UPRN must be 8 to 10 digits';
+  }, [filters.searchBy, filters.uprn]);
+
+  const isSearchDisabled = React.useMemo(() => !!uprnError, [uprnError]);
+
+  const handleSearch = React.useCallback(() => {
+    const sanitized = sanitizeFilters(filters);
+    if (sanitized.searchBy === 'uprn' && sanitized.uprn && (sanitized.uprn.length < 8 || sanitized.uprn.length > 10)) {
+      return;
+    }
+    setFilters(sanitized);
+    onSearch(sanitized);
+  }, [filters, onSearch]);
+
+  const handleClear = React.useCallback(() => {
+    const defaults = createDefaultGridFilters();
+    setFilters(defaults);
+    onSearch(defaults);
+  }, [onSearch]);
+
+  const showPostcodeHint = React.useMemo(() => {
+    if (!filters.postcode || filters.postcode.length === 0) {
+      return false;
+    }
+    return filters.searchBy === 'postcode' || filters.searchBy === 'address';
+  }, [filters.postcode, filters.searchBy]);
 
   React.useEffect(() => {
     setColumns(
@@ -411,12 +572,140 @@ export const Grid = React.memo((props: GridProps) => {
             One or more column configurations reference fields that do not exist in the dataset.
           </MessageBar>
         )}
-        <TextField
-          placeholder="Search"
-          value={searchText}
-          onChange={(_, v) => onSearch(v ?? '')}
+        <Stack
+          horizontal
+          wrap
+          verticalAlign="end"
+          tokens={{ childrenGap: 16 }}
           style={{ marginBottom: 16 }}
-        />
+        >
+          <Stack.Item grow styles={{ root: { minWidth: 0 } }}>
+            <Stack
+              horizontal
+              wrap
+              verticalAlign="end"
+              tokens={{ childrenGap: 16 }}
+              styles={{ root: { rowGap: 12 } }}
+            >
+              <Stack.Item styles={{ root: { minWidth: 200 } }}>
+                <Dropdown
+                  label="Search by"
+                  options={searchByOptions}
+                  selectedKey={filters.searchBy}
+                  onChange={onSearchByChange}
+                  styles={{ dropdown: { width: '100%' } }}
+                />
+              </Stack.Item>
+              {filters.searchBy === 'uprn' && (
+                <Stack.Item styles={{ root: { minWidth: 200 } }}>
+                  <TextField
+                    label="UPRN"
+                    value={filters.uprn ?? ''}
+                    onChange={onUprnChange}
+                    onKeyDown={onFieldEnter}
+                    errorMessage={uprnError}
+                    inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}
+                  />
+                </Stack.Item>
+              )}
+              {filters.searchBy === 'taskId' && (
+                <Stack.Item styles={{ root: { minWidth: 200 } }}>
+                  <TextField
+                    label="Task ID"
+                    value={filters.taskId ?? ''}
+                    onChange={onTaskIdChange}
+                    onKeyDown={onFieldEnter}
+                  />
+                </Stack.Item>
+              )}
+              {filters.searchBy === 'manualCheck' && (
+                <Stack.Item styles={{ root: { minWidth: 180 } }}>
+                  <Dropdown
+                    label="Manual check"
+                    options={manualCheckOptions}
+                    selectedKey={filters.manualCheck ?? 'all'}
+                    onChange={onManualCheckChange}
+                    styles={{ dropdown: { width: '100%' } }}
+                  />
+                </Stack.Item>
+              )}
+              {filters.searchBy === 'address' && (
+                <>
+                  <Stack.Item styles={{ root: { minWidth: 200 } }}>
+                    <TextField
+                      label="Building name/number"
+                      value={filters.buildingNameNumber ?? ''}
+                      onChange={onBuildingNameChange}
+                      onKeyDown={onFieldEnter}
+                    />
+                  </Stack.Item>
+                  <Stack.Item styles={{ root: { minWidth: 200 } }}>
+                    <TextField
+                      label="Street"
+                      value={filters.street ?? ''}
+                      onChange={onStreetChange}
+                      onKeyDown={onFieldEnter}
+                    />
+                  </Stack.Item>
+                  <Stack.Item styles={{ root: { minWidth: 200 } }}>
+                    <TextField
+                      label="Town or city"
+                      value={filters.townCity ?? ''}
+                      onChange={onTownChange}
+                      onKeyDown={onFieldEnter}
+                    />
+                  </Stack.Item>
+                  <Stack.Item styles={{ root: { minWidth: 160 } }}>
+                    <TextField
+                      label="Postcode"
+                      value={filters.postcode ?? ''}
+                      onChange={onPostcodeChange}
+                      onKeyDown={onFieldEnter}
+                    />
+                    {showPostcodeHint && (
+                      <Text variant="small" styles={{ root: { marginTop: 4 } }}>
+                        Partial postcodes return all matching entries.
+                      </Text>
+                    )}
+                  </Stack.Item>
+                </>
+              )}
+              {filters.searchBy === 'postcode' && (
+                <Stack.Item styles={{ root: { minWidth: 160 } }}>
+                  <TextField
+                    label="Postcode"
+                    value={filters.postcode ?? ''}
+                    onChange={onPostcodeChange}
+                    onKeyDown={onFieldEnter}
+                  />
+                  {showPostcodeHint && (
+                    <Text variant="small" styles={{ root: { marginTop: 4 } }}>
+                      Partial postcodes return all matching entries.
+                    </Text>
+                  )}
+                </Stack.Item>
+              )}
+            </Stack>
+          </Stack.Item>
+          <Stack.Item styles={{ root: { display: 'flex', alignItems: 'flex-end' } }}>
+            <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 12 }}>
+              {(shimmer || itemsLoading || isComponentLoading) && (
+                <Spinner size={SpinnerSize.small} ariaLabel="Loading filter results" />
+              )}
+              <PrimaryButton text="Search" onClick={handleSearch} disabled={isSearchDisabled} />
+              <Link
+                onClick={(ev) => {
+                  ev.preventDefault();
+                  handleClear();
+                }}
+                aria-label="Clear all filters"
+                styles={{ root: { fontSize: 14 } }}
+              >
+                Clear all
+              </Link>
+            </Stack>
+          </Stack.Item>
+        </Stack>
         <ShimmeredDetailsList
           className={ClassNames.PowerCATFluentDetailsList}
           componentRef={componentRef}

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -5,13 +5,15 @@ import { ColumnConfig } from "./Component.types";
 import { SAMPLE_COLUMNS, SAMPLE_RECORDS } from "./SampleData";
 import * as React from "react";
 import { IDetailsList, ISelection, Selection, SelectionMode, IObjectWithKey } from '@fluentui/react';
+import { GridFilterState, createDefaultGridFilters, sanitizeFilters } from "./Filters";
 
 export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, IOutputs> {
     private notifyOutputChanged: () => void;
     private taskCache: Record<string, { statuscode?: string; ownerid?: { name?: string }; subject?: string }> = {};
     private selectedTaskId?: string;
-    private searchText = "";
+    private searchFilters: GridFilterState = createDefaultGridFilters();
     private currentPage = 0;
+    private lastQuickNavigateKey?: string;
     private columnDisplayNames: Record<string, string> = {};
     private lastColumnDisplayNamesRaw = "";
     private columnConfigs: Record<string, ColumnConfig> = {};
@@ -201,16 +203,20 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             (name) => !columnNamesSet.has(name),
         );
 
-        let filteredIds = allIds;
-        if (this.searchText) {
-            const search = this.searchText.toLowerCase();
-            filteredIds = filteredIds.filter((id) => {
-                const rec = records[id] as unknown as Record<string, unknown>;
-                return datasetColumns.some((c) => {
-                    const val = rec[c.name];
-                    return typeof val === "string" && val.toLowerCase().includes(search);
-                });
-            });
+        const filters = sanitizeFilters(this.searchFilters);
+        this.searchFilters = filters;
+        let filteredIds = allIds.filter((id) => {
+            const record = records[id] as unknown as Record<string, unknown>;
+            return this.matchesFilters(record, filters, datasetColumns);
+        });
+
+        let quickNavigateRecord: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord | undefined;
+        let quickNavigateKey: string | undefined;
+        if (filters.searchBy === "taskId" && filters.taskId) {
+            if (filteredIds.length === 1) {
+                quickNavigateRecord = records[filteredIds[0]];
+                quickNavigateKey = `${filters.taskId}:${filteredIds[0]}`;
+            }
         }
 
         const pageSize = context.parameters.pageSize.raw ?? 10;
@@ -238,9 +244,10 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             }
         };
 
-        const onSearch = (text: string): void => {
-            this.searchText = text;
+        const onSearch = (filterState: GridFilterState): void => {
+            this.searchFilters = sanitizeFilters(filterState);
             this.currentPage = 0;
+            this.lastQuickNavigateKey = undefined;
             this.notifyOutputChanged();
         };
 
@@ -316,10 +323,150 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             totalPages,
             canNext,
             canPrev,
-            searchText: this.searchText,
+            searchFilters: this.searchFilters,
         };
 
-        return React.createElement(Grid, props);
+        const element = React.createElement(Grid, props);
+
+        if (quickNavigateRecord && quickNavigateKey && this.lastQuickNavigateKey !== quickNavigateKey) {
+            this.lastQuickNavigateKey = quickNavigateKey;
+            onNavigate(quickNavigateRecord);
+        } else if (!quickNavigateRecord) {
+            this.lastQuickNavigateKey = undefined;
+        }
+
+        return element;
+    }
+
+    private matchesFilters(
+        record: Record<string, unknown>,
+        filters: GridFilterState,
+        datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[],
+    ): boolean {
+        switch (filters.searchBy) {
+            case "uprn": {
+                if (!filters.uprn) {
+                    return true;
+                }
+                const uprn = this.getRecordValue(record, "uprn", datasetColumns);
+                return uprn.includes(filters.uprn);
+            }
+            case "taskId": {
+                if (!filters.taskId) {
+                    return true;
+                }
+                const taskId = this.getRecordValue(record, "taskid", datasetColumns);
+                return taskId.toLowerCase().includes(filters.taskId.toLowerCase());
+            }
+            case "manualCheck": {
+                const desired = filters.manualCheck ?? "all";
+                if (desired === "all") {
+                    return true;
+                }
+                const manualCheck = this.getRecordValueFromCandidates(
+                    record,
+                    datasetColumns,
+                    ["manualcheck", "manualcheckflag", "manualqa"],
+                ).toLowerCase();
+                if (desired === "yes") {
+                    return manualCheck === "yes" || manualCheck === "true";
+                }
+                if (desired === "no") {
+                    return manualCheck === "no" || manualCheck === "false";
+                }
+                return true;
+            }
+            case "postcode": {
+                if (!filters.postcode) {
+                    return true;
+                }
+                const postcode = this.getRecordValueFromCandidates(record, datasetColumns, ["postcode", "post_code"]).toUpperCase();
+                return postcode.includes(filters.postcode);
+            }
+            case "address": {
+                const postcodeValue = this.getRecordValueFromCandidates(
+                    record,
+                    datasetColumns,
+                    ["postcode", "post_code"],
+                ).toUpperCase();
+                const postcodeFilter = filters.postcode
+                    ? postcodeValue.includes(filters.postcode)
+                    : true;
+                const buildingValue = this.getRecordValueFromCandidates(
+                    record,
+                    datasetColumns,
+                    ["buildingnamenumber", "buildingname", "buildingnumber"],
+                ).toLowerCase();
+                const buildingFilter = filters.buildingNameNumber
+                    ? buildingValue.includes(filters.buildingNameNumber.toLowerCase())
+                    : true;
+                const streetValue = this.getRecordValueFromCandidates(
+                    record,
+                    datasetColumns,
+                    ["street", "streetname", "addressline1"],
+                ).toLowerCase();
+                const streetFilter = filters.street
+                    ? streetValue.includes(filters.street.toLowerCase())
+                    : true;
+                const townValue = this.getRecordValueFromCandidates(
+                    record,
+                    datasetColumns,
+                    ["towncity", "town", "city"],
+                ).toLowerCase();
+                const townFilter = filters.townCity
+                    ? townValue.includes(filters.townCity.toLowerCase())
+                    : true;
+                return postcodeFilter && buildingFilter && streetFilter && townFilter;
+            }
+            default:
+                return true;
+        }
+    }
+
+    private getRecordValue(
+        record: Record<string, unknown>,
+        fieldName: string,
+        datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[],
+    ): string {
+        const direct = record[fieldName];
+        if (direct !== undefined) {
+            return this.toText(direct);
+        }
+        const lower = fieldName.toLowerCase();
+        const column = datasetColumns.find(
+            (col) => col.name?.toLowerCase() === lower || col.alias?.toLowerCase() === lower,
+        );
+        if (column) {
+            const value = record[column.name];
+            if (value !== undefined) {
+                return this.toText(value);
+            }
+        }
+        return "";
+    }
+
+    private getRecordValueFromCandidates(
+        record: Record<string, unknown>,
+        datasetColumns: ComponentFramework.PropertyHelper.DataSetApi.Column[],
+        candidates: string[],
+    ): string {
+        for (const candidate of candidates) {
+            const value = this.getRecordValue(record, candidate, datasetColumns);
+            if (value) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    private toText(value: unknown): string {
+        if (typeof value === "string") {
+            return value;
+        }
+        if (typeof value === "number" || typeof value === "boolean") {
+            return value.toString();
+        }
+        return "";
     }
 
     public getOutputs(): IOutputs {


### PR DESCRIPTION
## Summary
- add a GOV.UK-inspired filter bar with dynamic inputs driven by the "Search by" selection
- introduce shared filter helpers and apply the new filters when building the grid dataset
- keep quick task navigation logic and display a loading spinner alongside the search actions

## Testing
- npm run lint *(fails: existing ESLint `@typescript-eslint/no-unsafe-*` violations in the Fluent UI scaffolding)*

------
https://chatgpt.com/codex/tasks/task_e_68f15eebea44832c8bec930c30bf1c65