### PR TITLE
Fix lint issues for filtered IDs and UPRN text field

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -14,6 +14,7 @@ import {
   ISelection,
   IPartialTheme,
   IDropdownOption,
+  ITextField,
   PrimaryButton,
   SelectionMode,
   ShimmeredDetailsList,
@@ -197,6 +198,19 @@ export const Grid = React.memo((props: GridProps) => {
     },
     [],
   );
+
+  const uprnInputRef = React.useRef<ITextField | null>(null);
+  const setUprnInputRef = React.useCallback((ref: ITextField | null) => {
+    uprnInputRef.current = ref;
+    if (!ref) {
+      return;
+    }
+    const inputElement = ref.getElement()?.querySelector('input');
+    if (inputElement) {
+      inputElement.setAttribute('inputmode', 'numeric');
+      inputElement.setAttribute('pattern', '[0-9]*');
+    }
+  }, []);
 
   const onSearchByChange = React.useCallback(
     (_: React.FormEvent<HTMLDivElement>, option?: IDropdownOption) => {
@@ -604,7 +618,7 @@ export const Grid = React.memo((props: GridProps) => {
                     onChange={onUprnChange}
                     onKeyDown={onFieldEnter}
                     errorMessage={uprnError}
-                    inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}
+                    componentRef={setUprnInputRef}
                   />
                 </Stack.Item>
               )}

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -205,7 +205,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
 
         const filters = sanitizeFilters(this.searchFilters);
         this.searchFilters = filters;
-        let filteredIds = allIds.filter((id) => {
+        const filteredIds = allIds.filter((id) => {
             const record = records[id] as unknown as Record<string, unknown>;
             return this.matchesFilters(record, filters, datasetColumns);
         });


### PR DESCRIPTION
## Summary
- convert the filteredIds collection to a const so the dataset lint rule passes
- add a TextField ref that applies the numeric input attributes for the UPRN filter without relying on the missing inputProps type

## Testing
- npm run lint *(fails: existing type errors from @fluentui/react declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68f16149a570832ca26182425e7a99c7