### PR TITLE
Integrate APIM task search into DetailsListVOA

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -11,11 +11,8 @@
       <external-service-usage enabled="false">
       </external-service-usage>
     -->
-    <external-service-usage enabled="false">
-      <!--UNCOMMENT TO ADD EXTERNAL DOMAINS
-      <domain></domain>
-      <domain></domain>
-      -->
+    <external-service-usage enabled="true">
+      <domain>api.contoso.gov.uk</domain>
     </external-service-usage>
     <data-set name="revalSalesDataset" display-name-key="RevalSalesDataset" description-key="RevalSalesDataset description"/>
 
@@ -48,6 +45,15 @@
       usage="input"
       required="false"
       default-value="[]"
+    />
+    <property
+      name="apimEndpoint"
+      display-name-key="APIM Endpoint"
+      description-key="Fully qualified URL of the APIM search endpoint"
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value="https://api.contoso.gov.uk/revaluation/tasks"
     />
     <property name="selectedTaskId" display-name-key="SelectedTaskId" description-key="SelectedTaskId description" of-type="SingleLine.Text" usage="output" required="false" />
     <resources>

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -75,6 +75,7 @@ export interface GridProps {
   canPrev: boolean;
   overlayOnSort?: boolean;
   searchFilters: GridFilterState;
+  errorMessage?: string;
 }
 
 const defaultTheme = createTheme({
@@ -138,6 +139,7 @@ export const Grid = React.memo((props: GridProps) => {
     canPrev,
     overlayOnSort,
     searchFilters,
+    errorMessage,
   } = props;
 
   const theme = useTheme(themeJSON);
@@ -572,6 +574,11 @@ export const Grid = React.memo((props: GridProps) => {
         {columnDatasetNotDefined && (
           <MessageBar messageBarType={MessageBarType.error} style={{ marginBottom: 16 }}>
             One or more column configurations reference fields that do not exist in the dataset.
+          </MessageBar>
+        )}
+        {errorMessage && (
+          <MessageBar messageBarType={MessageBarType.error} style={{ marginBottom: 16 }}>
+            {errorMessage}
           </MessageBar>
         )}
         <Stack

--- a/DetailsListVOA/TaskSearchSample.ts
+++ b/DetailsListVOA/TaskSearchSample.ts
@@ -1,0 +1,120 @@
+export interface TaskSearchItem {
+    uprn: string;
+    taskId: string;
+    taskStatus: string;
+    caseAssignedTo: string;
+    address: string;
+    postcode: string;
+    transactionDate: string;
+    source: string;
+}
+
+export interface TaskSearchResponse {
+    items: TaskSearchItem[];
+    totalCount: number;
+    page: number;
+    pageSize: number;
+}
+
+export const SAMPLE_TASK_RESULTS: TaskSearchItem[] = [
+    {
+        uprn: "100021234567",
+        taskId: "T-00001",
+        taskStatus: "Open",
+        caseAssignedTo: "Jamie Reid",
+        address: "1 Market Street, Bristol",
+        postcode: "BS1 1AA",
+        transactionDate: "2024-04-17T09:30:00Z",
+        source: "Ratepayer Portal",
+    },
+    {
+        uprn: "100021234568",
+        taskId: "T-00002",
+        taskStatus: "Pending Review",
+        caseAssignedTo: "Priya Singh",
+        address: "24 High Road, London",
+        postcode: "N10 2DB",
+        transactionDate: "2024-04-18T15:42:00Z",
+        source: "Internal Referral",
+    },
+    {
+        uprn: "100021234569",
+        taskId: "T-00003",
+        taskStatus: "Completed",
+        caseAssignedTo: "Lee Carter",
+        address: "Flat 3, 9 Albert Square, Manchester",
+        postcode: "M15 4EF",
+        transactionDate: "2024-04-12T11:05:00Z",
+        source: "Bulk Import",
+    },
+    {
+        uprn: "100021234570",
+        taskId: "T-00004",
+        taskStatus: "Open",
+        caseAssignedTo: "Alex Morgan",
+        address: "77 Castle View, Edinburgh",
+        postcode: "EH3 5LP",
+        transactionDate: "2024-04-22T08:14:00Z",
+        source: "Ratepayer Portal",
+    },
+    {
+        uprn: "100021234571",
+        taskId: "T-00005",
+        taskStatus: "In Progress",
+        caseAssignedTo: "Hannah Walsh",
+        address: "12 Riverside Walk, Leeds",
+        postcode: "LS2 7QA",
+        transactionDate: "2024-04-19T13:27:00Z",
+        source: "Agent Submission",
+    },
+    {
+        uprn: "100021234572",
+        taskId: "T-00006",
+        taskStatus: "Open",
+        caseAssignedTo: "Samir Patel",
+        address: "5 Orchard Close, Birmingham",
+        postcode: "B1 2RT",
+        transactionDate: "2024-04-21T10:52:00Z",
+        source: "Bulk Import",
+    },
+    {
+        uprn: "100021234573",
+        taskId: "T-00007",
+        taskStatus: "Pending Review",
+        caseAssignedTo: "Rebecca Chen",
+        address: "42 Queen Street, Cardiff",
+        postcode: "CF10 1AB",
+        transactionDate: "2024-04-20T16:18:00Z",
+        source: "Internal Referral",
+    },
+    {
+        uprn: "100021234574",
+        taskId: "T-00008",
+        taskStatus: "Completed",
+        caseAssignedTo: "Oliver Grant",
+        address: "Flat 2, 88 King’s Road, Reading",
+        postcode: "RG1 2LN",
+        transactionDate: "2024-04-10T09:01:00Z",
+        source: "Ratepayer Portal",
+    },
+    {
+        uprn: "100021234575",
+        taskId: "T-00009",
+        taskStatus: "On Hold",
+        caseAssignedTo: "Maria Gomez",
+        address: "19 Meadow Lane, Nottingham",
+        postcode: "NG2 3BD",
+        transactionDate: "2024-04-23T12:44:00Z",
+        source: "Agent Submission",
+    },
+    {
+        uprn: "100021234576",
+        taskId: "T-00010",
+        taskStatus: "Open",
+        caseAssignedTo: "Liam O’Connor",
+        address: "31 Harbour View, Belfast",
+        postcode: "BT1 3FG",
+        transactionDate: "2024-04-24T07:55:00Z",
+        source: "Ratepayer Portal",
+    },
+];

--- a/DetailsListVOA/generated/ManifestTypes.ts
+++ b/DetailsListVOA/generated/ManifestTypes.ts
@@ -6,6 +6,7 @@ export interface IInputs {
     pageSize: ComponentFramework.PropertyTypes.WholeNumberProperty;
     columnDisplayNames: ComponentFramework.PropertyTypes.StringProperty;
     columnConfig: ComponentFramework.PropertyTypes.StringProperty;
+    apimEndpoint: ComponentFramework.PropertyTypes.StringProperty;
 }
 
 export interface IOutputs {

--- a/DetailsListVOA/index.ts
+++ b/DetailsListVOA/index.ts
@@ -3,6 +3,7 @@ import { IInputs, IOutputs } from "./generated/ManifestTypes";
 import { Grid, GridProps } from "./Grid";
 import { ColumnConfig } from "./Component.types";
 import { SAMPLE_COLUMNS, SAMPLE_RECORDS } from "./SampleData";
+import { SAMPLE_TASK_RESULTS, TaskSearchItem, TaskSearchResponse } from "./TaskSearchSample";
 import * as React from "react";
 import { IDetailsList, ISelection, Selection, SelectionMode, IObjectWithKey } from '@fluentui/react';
 import { GridFilterState, createDefaultGridFilters, sanitizeFilters } from "./Filters";
@@ -18,6 +19,10 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
     private lastColumnDisplayNamesRaw = "";
     private columnConfigs: Record<string, ColumnConfig> = {};
     private lastColumnConfigRaw = "";
+    private apimItems: TaskSearchItem[] = [];
+    private apimLoading = false;
+    private apimError?: string;
+    private hasLoadedApim = false;
 
     constructor() {
         // Empty
@@ -103,7 +108,14 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             } as ComponentFramework.PropertyHelper.DataSetApi.Column);
         };
 
-        ensureColumn("taskstatus", "Task Status");
+        ensureColumn("uprn", "UPRN", 120);
+        ensureColumn("taskid", "Task ID", 120);
+        ensureColumn("taskstatus", "Task Status", 120);
+        ensureColumn("caseassignedto", "Case Assigned To", 160);
+        ensureColumn("address", "Address", 240);
+        ensureColumn("postcode", "Postcode", 110);
+        ensureColumn("transactiondate", "Transaction Date", 160);
+        ensureColumn("source", "Source", 120);
         ensureColumn("assignedto", "Assigned To");
         ensureColumn("tasktitle", "Task Title");
         ensureColumn("action", "Action");
@@ -172,7 +184,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             allIds.push(id);
         });
 
-        if (allIds.length === 0 && !dataset.loading) {
+        if (allIds.length === 0 && !dataset.loading && !this.hasLoadedApim) {
             SAMPLE_COLUMNS.forEach((column) => ensureColumn(column.name, column.displayName, column.width));
             SAMPLE_RECORDS.forEach((sample, index) => {
                 const recordBase: Record<string, unknown> = {};
@@ -190,6 +202,22 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             });
         }
 
+        let activeRecords = records;
+        let activeIds = allIds;
+
+        if (this.hasLoadedApim) {
+            const remoteRecords: Record<string, ComponentFramework.PropertyHelper.DataSetApi.EntityRecord> = {};
+            const remoteIds: string[] = [];
+            this.apimItems.forEach((item, index) => {
+                const record = this.createRecordFromApim(item, index);
+                const recordId = record.getRecordId();
+                remoteRecords[recordId] = record as ComponentFramework.PropertyHelper.DataSetApi.EntityRecord;
+                remoteIds.push(recordId);
+            });
+            activeRecords = remoteRecords;
+            activeIds = remoteIds;
+        }
+
         const columnNamesSet = new Set<string>();
         datasetColumns.forEach((c) => {
             if (c.name) {
@@ -205,8 +233,8 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
 
         const filters = sanitizeFilters(this.searchFilters);
         this.searchFilters = filters;
-        const filteredIds = allIds.filter((id) => {
-            const record = records[id] as unknown as Record<string, unknown>;
+        const filteredIds = activeIds.filter((id) => {
+            const record = activeRecords[id] as unknown as Record<string, unknown>;
             return this.matchesFilters(record, filters, datasetColumns);
         });
 
@@ -214,7 +242,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         let quickNavigateKey: string | undefined;
         if (filters.searchBy === "taskId" && filters.taskId) {
             if (filteredIds.length === 1) {
-                quickNavigateRecord = records[filteredIds[0]];
+                quickNavigateRecord = activeRecords[filteredIds[0]];
                 quickNavigateKey = `${filters.taskId}:${filteredIds[0]}`;
             }
         }
@@ -226,8 +254,9 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const start = this.currentPage * pageSize;
         const pageIds = filteredIds.slice(start, start + pageSize);
         const canPrev = this.currentPage > 0;
-        const canNext = start + pageSize < filteredIds.length || dataset.paging.hasNextPage;
-        const totalPages = Math.ceil(filteredIds.length / pageSize) + (dataset.paging.hasNextPage ? 1 : 0);
+        const datasetHasNext = this.hasLoadedApim ? false : dataset.paging.hasNextPage;
+        const canNext = start + pageSize < filteredIds.length || datasetHasNext;
+        const totalPages = Math.ceil(filteredIds.length / pageSize) + (datasetHasNext ? 1 : 0);
 
         const onNavigate = (
             item?: ComponentFramework.PropertyHelper.DataSetApi.EntityRecord,
@@ -249,12 +278,13 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             this.currentPage = 0;
             this.lastQuickNavigateKey = undefined;
             this.notifyOutputChanged();
+            void this.loadTasks(context, this.searchFilters);
         };
 
         const onNextPage = (): void => {
             if (canNext) {
                 const nextStart = (this.currentPage + 1) * pageSize;
-                if (nextStart >= filteredIds.length && dataset.paging.hasNextPage) {
+                if (nextStart >= filteredIds.length && datasetHasNext) {
                     dataset.paging.loadNextPage();
                 }
                 this.currentPage += 1;
@@ -272,7 +302,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const onSetPage = (page: number): void => {
             if (page >= 0 && page !== this.currentPage) {
                 const targetStart = page * pageSize;
-                if (targetStart >= filteredIds.length && dataset.paging.hasNextPage) {
+                if (targetStart >= filteredIds.length && datasetHasNext) {
                     dataset.paging.loadNextPage();
                 }
                 this.currentPage = page;
@@ -303,10 +333,10 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         const props: GridProps = {
             datasetColumns,
             columnConfigs: this.columnConfigs,
-            records,
+            records: activeRecords,
             sortedRecordIds: pageIds,
-            shimmer: dataset.loading,
-            itemsLoading: dataset.loading,
+            shimmer: dataset.loading || this.apimLoading,
+            itemsLoading: dataset.loading || this.apimLoading,
             selectionType: SelectionMode.none,
             selection,
             onNavigate,
@@ -324,6 +354,7 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
             canNext,
             canPrev,
             searchFilters: this.searchFilters,
+            errorMessage: this.apimError,
         };
 
         const element = React.createElement(Grid, props);
@@ -336,6 +367,145 @@ export class DetailsListVOA implements ComponentFramework.ReactControl<IInputs, 
         }
 
         return element;
+    }
+
+    private createRecordFromApim(
+        item: TaskSearchItem,
+        index: number,
+    ): ComponentFramework.PropertyHelper.DataSetApi.EntityRecord & Record<string, unknown> {
+        const recordBase: Record<string, unknown> = {};
+        const record = recordBase as ComponentFramework.PropertyHelper.DataSetApi.EntityRecord & Record<string, unknown>;
+        const recordId = item.taskId || `${item.uprn}-${index}` || `apim-${index}`;
+        record.getRecordId = () => recordId;
+        record.getNamedReference = undefined as unknown as ComponentFramework.PropertyHelper.DataSetApi.EntityRecord['getNamedReference'];
+        record.getValue = ((columnName: string) => record[columnName] ?? "") as ComponentFramework.PropertyHelper.DataSetApi.EntityRecord['getValue'];
+        record.getFormattedValue = ((columnName: string) => {
+            const value = record[columnName];
+            if (typeof value === "string") {
+                return value;
+            }
+            if (typeof value === "number" || typeof value === "boolean") {
+                return value.toString();
+            }
+            return "";
+        }) as ComponentFramework.PropertyHelper.DataSetApi.EntityRecord['getFormattedValue'];
+
+        const formattedDate = this.tryFormatDate(item.transactionDate);
+
+        record.uprn = item.uprn;
+        record.taskid = item.taskId;
+        record.taskId = item.taskId;
+        record.taskstatus = item.taskStatus;
+        record.taskStatus = item.taskStatus;
+        record.caseassignedto = item.caseAssignedTo;
+        record.caseAssignedTo = item.caseAssignedTo;
+        record.address = item.address;
+        record.postcode = item.postcode;
+        record.transactiondate = formattedDate;
+        record.transactionDate = formattedDate;
+        record.source = item.source;
+        record.saleId = "";
+        record.action = "🔍 View / Edit";
+
+        return record;
+    }
+
+    private tryFormatDate(value?: string): string {
+        if (!value) {
+            return "";
+        }
+        const parsed = new Date(value);
+        if (Number.isNaN(parsed.getTime())) {
+            return value;
+        }
+        return parsed.toLocaleString("en-GB", {
+            day: "2-digit",
+            month: "short",
+            year: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    }
+
+    private async loadTasks(
+        context: ComponentFramework.Context<IInputs>,
+        filters: GridFilterState,
+    ): Promise<void> {
+        const configuredEndpoint = context.parameters.apimEndpoint?.raw?.trim();
+        const baseUrl = configuredEndpoint && configuredEndpoint.length > 0
+            ? configuredEndpoint
+            : "https://api.contoso.gov.uk/revaluation/tasks";
+        if (!baseUrl) {
+            return;
+        }
+
+        let requestUrl: URL;
+        try {
+            requestUrl = new URL(baseUrl);
+        } catch {
+            this.apimError = "Invalid APIM endpoint URL.";
+            this.hasLoadedApim = true;
+            this.apimItems = SAMPLE_TASK_RESULTS;
+            this.notifyOutputChanged();
+            return;
+        }
+
+        requestUrl.searchParams.set("searchBy", filters.searchBy);
+        const pageSize = context.parameters.pageSize.raw ?? 10;
+        requestUrl.searchParams.set("page", this.currentPage.toString());
+        requestUrl.searchParams.set("pageSize", pageSize.toString());
+
+        if (filters.searchBy === "uprn" && filters.uprn) {
+            requestUrl.searchParams.set("uprn", filters.uprn);
+        }
+        if (filters.searchBy === "taskId" && filters.taskId) {
+            requestUrl.searchParams.set("taskId", filters.taskId);
+        }
+        if (filters.searchBy === "postcode" && filters.postcode) {
+            requestUrl.searchParams.set("postcode", filters.postcode);
+        }
+        if (filters.searchBy === "address") {
+            if (filters.buildingNameNumber) {
+                requestUrl.searchParams.set("buildingName", filters.buildingNameNumber);
+            }
+            if (filters.street) {
+                requestUrl.searchParams.set("street", filters.street);
+            }
+            if (filters.townCity) {
+                requestUrl.searchParams.set("town", filters.townCity);
+            }
+            if (filters.postcode) {
+                requestUrl.searchParams.set("postcode", filters.postcode);
+            }
+        }
+        if (filters.searchBy === "manualCheck" && filters.manualCheck && filters.manualCheck !== "all") {
+            requestUrl.searchParams.set("manualCheck", filters.manualCheck);
+        }
+
+        this.apimLoading = true;
+        this.apimError = undefined;
+        this.notifyOutputChanged();
+
+        try {
+            const response = await context.httpClient.fetch(requestUrl.toString(), {
+                method: "GET",
+            });
+            if (!response.ok) {
+                throw new Error(`APIM request failed with status ${response.status}`);
+            }
+            const payload = (await response.json()) as TaskSearchResponse;
+            this.apimItems = payload.items ?? [];
+            this.apimError = undefined;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Unexpected error calling APIM.";
+            this.apimError = message;
+            // Provide deterministic fallback data so the grid remains populated in offline scenarios.
+            this.apimItems = SAMPLE_TASK_RESULTS;
+        } finally {
+            this.apimLoading = false;
+            this.hasLoadedApim = true;
+            this.notifyOutputChanged();
+        }
     }
 
     private matchesFilters(


### PR DESCRIPTION
## Summary
- allow makers to configure an APIM endpoint and document the required domain for the control
- fetch APIM task search results on demand, map them into the grid, and fall back to curated sample data when the call fails
- surface API errors and loading state in the grid while ensuring required columns exist for the remote payload

## Testing
- npm run lint *(fails: existing lint violations in Grid.tsx/GridCell.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f1714f72a4832ca235ee3f14863793