### PR TITLE
Add Canvas-bound prefilter inputs and pass them to APIM requests

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -71,6 +71,69 @@
       required="false"
       default-value="https://api.contoso.gov.uk/revaluation/tasks"
     />
+    <property
+      name="searchBy"
+      display-name-key="Search By"
+      description-key="Prefilter mode (e.g., Billing Authority or Caseworker)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
+    <property
+      name="billingAuthorities"
+      display-name-key="Billing Authorities"
+      description-key="Selected billing authorities (JSON array or comma-separated)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
+    <property
+      name="caseworkers"
+      display-name-key="Caseworkers"
+      description-key="Selected caseworkers (JSON array or comma-separated)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
+    <property
+      name="workThat"
+      display-name-key="Work That"
+      description-key="Selected work-that filter option."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
+    <property
+      name="fromDate"
+      display-name-key="From Date"
+      description-key="Filter from date (YYYY-MM-DD)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
+    <property
+      name="toDate"
+      display-name-key="To Date"
+      description-key="Filter to date (YYYY-MM-DD)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
+    <property
+      name="searchTrigger"
+      display-name-key="Search Trigger"
+      description-key="Updated on Search click to trigger a refresh."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value=""
+    />
     <!-- Removed search UI configuration properties; composition is component-based -->
     <!-- Removed sample search toggle -->
     <property

--- a/DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx
+++ b/DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx
@@ -361,7 +361,7 @@ export const DetailsListHost: React.FC<DetailsListHostProps> = ({ context, onRow
   }, [externalItems]);
 
   // Initial load and reloads when critical props change (skips when externalItems are supplied)
-  const lastRef = React.useRef<{ apim?: string; apiName?: string; table?: string }>({});
+  const lastRef = React.useRef<{ apim?: string; apiName?: string; table?: string; trigger?: string }>({});
   React.useEffect(() => {
     if (externalItems !== undefined) {
       // External data path; do not load from APIM
@@ -369,9 +369,14 @@ export const DetailsListHost: React.FC<DetailsListHostProps> = ({ context, onRow
     }
     const apim = (context.parameters as unknown as Record<string, { raw?: string }>).apimEndpoint?.raw?.trim() ?? '';
     const apiName = (context.parameters as unknown as Record<string, { raw?: string }>).customApiName?.raw?.trim() ?? '';
-    const changed = lastRef.current.apim !== apim || lastRef.current.apiName !== apiName || lastRef.current.table !== tableKey || !hasLoadedApim;
+    const trigger = String((context.parameters as unknown as Record<string, { raw?: string | number }>).searchTrigger?.raw ?? '');
+    const changed = lastRef.current.apim !== apim
+      || lastRef.current.apiName !== apiName
+      || lastRef.current.table !== tableKey
+      || lastRef.current.trigger !== trigger
+      || !hasLoadedApim;
     if (!changed) return;
-    lastRef.current = { apim, apiName, table: tableKey };
+    lastRef.current = { apim, apiName, table: tableKey, trigger };
     setApimLoading(true);
     void (async () => {
       const res = await loadGridData(context, {

--- a/DetailsListVOA/generated/ManifestTypes.ts
+++ b/DetailsListVOA/generated/ManifestTypes.ts
@@ -7,6 +7,13 @@ export interface IInputs {
     columnConfigProfile: ComponentFramework.PropertyTypes.StringProperty;
     apiBaseUrl: ComponentFramework.PropertyTypes.StringProperty;
     apimEndpoint: ComponentFramework.PropertyTypes.StringProperty;
+    searchBy: ComponentFramework.PropertyTypes.StringProperty;
+    billingAuthorities: ComponentFramework.PropertyTypes.StringProperty;
+    caseworkers: ComponentFramework.PropertyTypes.StringProperty;
+    workThat: ComponentFramework.PropertyTypes.StringProperty;
+    fromDate: ComponentFramework.PropertyTypes.StringProperty;
+    toDate: ComponentFramework.PropertyTypes.StringProperty;
+    searchTrigger: ComponentFramework.PropertyTypes.StringProperty;
     customApiName: ComponentFramework.PropertyTypes.StringProperty;
     tableKey: ComponentFramework.PropertyTypes.StringProperty;
 }

--- a/DetailsListVOA/services/GridDataController.ts
+++ b/DetailsListVOA/services/GridDataController.ts
@@ -14,6 +14,41 @@ export interface LoadResult {
   serverDriven: boolean;
 }
 
+const getPrefilterParams = (context: ComponentFramework.Context<IInputs>): Record<string, string> => {
+  const params = context.parameters as unknown as Record<string, { raw?: string | number | boolean }>;
+  const normalizeText = (raw?: string | number | boolean): string => {
+    if (raw === undefined || raw === null) return '';
+    const text = String(raw).trim();
+    return text;
+  };
+  const normalizeMulti = (raw?: string | number | boolean): string => {
+    const text = normalizeText(raw);
+    if (!text) return '';
+    try {
+      const parsed = JSON.parse(text);
+      if (Array.isArray(parsed)) {
+        return parsed.map((value) => String(value).trim()).filter((value) => value !== '').join(',');
+      }
+    } catch {
+      // ignore JSON parsing errors; fall back to raw text
+    }
+    return text;
+  };
+  const addIfPresent = (obj: Record<string, string>, key: string, value: string): void => {
+    if (value.trim().length > 0) {
+      obj[key] = value.trim();
+    }
+  };
+  const result: Record<string, string> = {};
+  addIfPresent(result, 'searchBy', normalizeText(params.searchBy?.raw));
+  addIfPresent(result, 'billingAuthorities', normalizeMulti(params.billingAuthorities?.raw));
+  addIfPresent(result, 'caseworkers', normalizeMulti(params.caseworkers?.raw));
+  addIfPresent(result, 'workThat', normalizeText(params.workThat?.raw));
+  addIfPresent(result, 'fromDate', normalizeText(params.fromDate?.raw));
+  addIfPresent(result, 'toDate', normalizeText(params.toDate?.raw));
+  return result;
+};
+
 export async function loadGridData(
   context: ComponentFramework.Context<IInputs>,
   args: {
@@ -40,6 +75,7 @@ export async function loadGridData(
 
   const pageSize = (context.parameters as unknown as Record<string, { raw?: number }>).pageSize?.raw ?? 10;
   const apiParamsBase = buildApiParamsFor(args.tableKey, args.filters as never, args.currentPage, pageSize);
+  const prefilterParams = getPrefilterParams(context);
   const headerFilterEntries = Object.entries(args.headerFilters).filter(([_, v]) =>
     Array.isArray(v) ? v.length > 0 : (v ?? '').toString().trim() !== '',
   );
@@ -49,7 +85,12 @@ export async function loadGridData(
   const sortBy = args.clientSort?.name;
   const sortDirection = args.clientSort?.sortDirection;
   const buildParams = (page: number) => {
-    const p: Record<string, string> = { ...apiParamsBase, page: String(page), pageSize: String(pageSize) };
+    const p: Record<string, string> = {
+      ...apiParamsBase,
+      ...prefilterParams,
+      page: String(page),
+      pageSize: String(pageSize),
+    };
     if (sortBy) p.sortBy = sortBy;
     if (typeof sortDirection === 'number') p.sortDirection = String(sortDirection);
     return p;


### PR DESCRIPTION
### Motivation
- Allow Canvas app screen controls to bind manager prefilters into the PCF using the existing manifest input pattern. 
- Support a dedicated `searchTrigger` so searches only run when the user clicks Search (prevent auto-search on every filter change). 
- Ensure prefilter values are included when the PCF builds API request parameters so server-side filtering can be applied. 
- Keep input typings in sync so the PCF can read new inputs via `context.parameters.*.raw`.

### Description
- Added new input properties in `ControlManifest.Input.xml` for `searchBy`, `billingAuthorities`, `caseworkers`, `workThat`, `fromDate`, `toDate`, and `searchTrigger`.
- Updated generated input typings in `DetailsListVOA/generated/ManifestTypes.ts` to expose the new inputs to the control runtime.
- Updated `DetailsListHost.tsx` to watch the `searchTrigger` input and treat it as a change trigger so the host reloads when Search is clicked (change detection includes `searchTrigger`).
- Implemented `getPrefilterParams` in `DetailsListVOA/services/GridDataController.ts` and merged its output into the API request parameters (including JSON-array parsing for multi-selects), so requests include the prefilter keys.

### Testing
- No automated tests were run for this change.
- CI/unit tests were not executed as part of this update.
- Local type/compile checks were not reported (no automated build output captured).
- Manual validation is recommended after wiring Canvas bindings and running the control in the host environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ed05bc61c832ca8f647101bd80c35)