### PR TITLE
Condense pagination display with ellipses

### DIFF
--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -1728,19 +1728,42 @@ export const Grid = React.memo((props: GridProps) => {
             disabled={!canPrev}
             styles={{ root: { height: 32, padding: '0 8px' } }}
           />
-          {Array.from({ length: totalPages }, (_, i) => (
-            <Text
-              key={`page-${i}`}
-              style={{
-                cursor: 'pointer',
-                fontWeight: i === currentPage ? 600 : undefined,
-                fontSize: 14,
-              }}
-              onClick={() => (i === currentPage ? undefined : onSetPage(i))}
-            >
-              {i + 1}
-            </Text>
-          ))}
+          {(() => {
+            const pageItems: Array<number | 'ellipsis'> = [];
+            if (totalPages <= 5) {
+              pageItems.push(...Array.from({ length: totalPages }, (_, i) => i));
+            } else if (currentPage <= 1) {
+              pageItems.push(0, 1, 2, 'ellipsis', totalPages - 1);
+            } else if (currentPage >= totalPages - 2) {
+              pageItems.push(0, 'ellipsis', totalPages - 3, totalPages - 2, totalPages - 1);
+            } else {
+              pageItems.push(0, 'ellipsis', currentPage - 1, currentPage, currentPage + 1, 'ellipsis', totalPages - 1);
+            }
+
+            return pageItems.map((item, index) => {
+              if (item === 'ellipsis') {
+                return (
+                  <Text key={`page-ellipsis-${index}`} style={{ fontSize: 14 }}>
+                    ...
+                  </Text>
+                );
+              }
+
+              return (
+                <Text
+                  key={`page-${item}`}
+                  style={{
+                    cursor: 'pointer',
+                    fontWeight: item === currentPage ? 600 : undefined,
+                    fontSize: 14,
+                  }}
+                  onClick={() => (item === currentPage ? undefined : onSetPage(item))}
+                >
+                  {item + 1}
+                </Text>
+              );
+            });
+          })()}
           <DefaultButton
             text="Next"
             onClick={onNextPage}
@@ -1755,4 +1778,3 @@ export const Grid = React.memo((props: GridProps) => {
 });
 
 Grid.displayName = 'Grid';
-

--- a/DetailsListVOA/grid/Grid.tsx
+++ b/DetailsListVOA/grid/Grid.tsx
@@ -1319,19 +1319,42 @@ export const Grid = React.memo((props: GridProps) => {
             disabled={!canPrev}
             styles={{ root: { height: 32, padding: '0 8px' } }}
           />
-          {Array.from({ length: totalPages }, (_, i) => (
-            <Text
-              key={`page-${i}`}
-              style={{
-                cursor: 'pointer',
-                fontWeight: i === currentPage ? 600 : undefined,
-                fontSize: 14,
-              }}
-              onClick={() => (i === currentPage ? undefined : onSetPage(i))}
-            >
-              {i + 1}
-            </Text>
-          ))}
+          {(() => {
+            const pageItems: Array<number | 'ellipsis'> = [];
+            if (totalPages <= 5) {
+              pageItems.push(...Array.from({ length: totalPages }, (_, i) => i));
+            } else if (currentPage <= 1) {
+              pageItems.push(0, 1, 2, 'ellipsis', totalPages - 1);
+            } else if (currentPage >= totalPages - 2) {
+              pageItems.push(0, 'ellipsis', totalPages - 3, totalPages - 2, totalPages - 1);
+            } else {
+              pageItems.push(0, 'ellipsis', currentPage - 1, currentPage, currentPage + 1, 'ellipsis', totalPages - 1);
+            }
+
+            return pageItems.map((item, index) => {
+              if (item === 'ellipsis') {
+                return (
+                  <Text key={`page-ellipsis-${index}`} style={{ fontSize: 14 }}>
+                    ...
+                  </Text>
+                );
+              }
+
+              return (
+                <Text
+                  key={`page-${item}`}
+                  style={{
+                    cursor: 'pointer',
+                    fontWeight: item === currentPage ? 600 : undefined,
+                    fontSize: 14,
+                  }}
+                  onClick={() => (item === currentPage ? undefined : onSetPage(item))}
+                >
+                  {item + 1}
+                </Text>
+              );
+            });
+          })()}
           <DefaultButton
             text="Next"
             onClick={onNextPage}
@@ -1346,4 +1369,3 @@ export const Grid = React.memo((props: GridProps) => {
 });
 
 Grid.displayName = 'Grid';
-


### PR DESCRIPTION
### Motivation
- Reduce pagination clutter by showing condensed page ranges with ellipses when there are many pages.
- Implement behavior like "1 2 3 ... 5" instead of rendering every page number.
- Keep current-page emphasis and the existing previous/next navigation intact.

### Description
- Replace full page number rendering in `DetailsListVOA/Grid.tsx` and `DetailsListVOA/grid/Grid.tsx` with a condensed `pageItems` array that includes numbers and `'ellipsis'` tokens.
- Render patterns for small counts (`totalPages <= 5`), leading/trailing ranges, and a centered window around `currentPage` with ellipses for large page counts.
- Preserve existing styling and click behavior by continuing to use `onSetPage`, `onNextPage`, and `onPrevPage` for interaction.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ef1163498832c9d9ab4fb272ff9a2)