### PR TITLE
Use svtGetSaleRecords custom API for sales search and normalize APIM params/responses

### DIFF
--- a/DetailsListVOA/Filters.ts
+++ b/DetailsListVOA/Filters.ts
@@ -58,7 +58,7 @@ export interface GridFilterState {
   salePrice?: NumericFilter;
   ratio?: NumericFilter;
   dwellingType?: string[];
-  flaggedForReview?: 'yes' | 'no';
+  flaggedForReview?: 'true' | 'false';
   reviewFlags?: string[];
   outlierKeySale?: string[];
   outlierRatio?: NumericFilter;

--- a/DetailsListVOA/Grid.tsx
+++ b/DetailsListVOA/Grid.tsx
@@ -211,8 +211,8 @@ const SEARCH_FIELD_CONFIGS: Record<SearchByOption, SearchFieldConfig> = {
     control: 'singleSelect',
     stateKey: 'flaggedForReview',
     options: [
-      { key: 'yes', text: 'Yes' },
-      { key: 'no', text: 'No' },
+      { key: 'true', text: 'Yes' },
+      { key: 'false', text: 'No' },
     ],
   },
   reviewFlags: {

--- a/DetailsListVOA/config/ControlConfig.ts
+++ b/DetailsListVOA/config/ControlConfig.ts
@@ -1,6 +1,6 @@
 export const CONTROL_CONFIG = {
   apiBaseUrl: '',
-  apimEndpoint: 'https://api.contoso.gov.uk/revaluation/tasks',
-  customApiName: '',
+  apimEndpoint: 'https://api.contoso.gov.uk/revaluation/sales',
+  customApiName: 'svtGetSaleRecords',
   tableKey: 'sales',
 };

--- a/DetailsListVOA/config/TableConfigs.ts
+++ b/DetailsListVOA/config/TableConfigs.ts
@@ -54,7 +54,7 @@ const SALES_COLUMN_FILTERS: Record<string, ColumnFilterConfig> = {
   saleprice: { control: 'numeric', minLength: 1 },
   ratio: { control: 'numeric', minLength: 1 },
   dwellingtype: { control: 'multiSelect', optionFields: ['dwellingtype'], selectAllValues: ['all'], minLength: 1 },
-  flaggedforreview: { control: 'singleSelect', options: ['yes', 'no'], minLength: 1 },
+  flaggedforreview: { control: 'singleSelect', options: ['true', 'false'], minLength: 1 },
   reviewflags: { control: 'multiSelect', optionFields: ['reviewflags'], minLength: 1 },
   outlierratio: { control: 'numeric', minLength: 1 },
   overallflag: {
@@ -86,60 +86,98 @@ const buildSalesParams = (
   pageSize: number,
 ): Record<string, string> => {
   const params: Record<string, string> = {
-    searchBy: filters.searchBy,
-    page: String(page),
+    pageNumber: String(page + 1),
     pageSize: String(pageSize),
   };
 
+  if (filters.source) params.source = filters.source;
   if (filters.saleId) params.saleId = filters.saleId;
   if (filters.taskId) params.taskId = filters.taskId;
   if (filters.uprn) params.uprn = filters.uprn;
   if (filters.address) params.address = filters.address;
+  if (filters.buildingNameNumber) params.buildingNameOrNumber = filters.buildingNameNumber;
+  if (filters.street) params.street = filters.street;
+  if (filters.townCity) params.town = filters.townCity;
   if (filters.postcode) params.postcode = filters.postcode;
   if (filters.billingAuthority?.length) params.billingAuthority = filters.billingAuthority.join(',');
+  if (filters.bacode) params.billingAuthorityReference = filters.bacode;
   if (filters.transactionDate) {
-    if (filters.transactionDate.from) params.transactionDateFrom = filters.transactionDate.from;
-    if (filters.transactionDate.to) params.transactionDateTo = filters.transactionDate.to;
+    const from = filters.transactionDate.from;
+    const to = filters.transactionDate.to;
+    if (from && to && from === to) {
+      params.transactionDate = from;
+    } else if (from && !to) {
+      params.transactionDate = from;
+    } else if (to && !from) {
+      params.transactionDate = to;
+    } else if (from) {
+      params.transactionDate = from;
+    }
   }
   if (filters.salePrice) {
-    params.salePriceMode = filters.salePrice.mode;
-    if (filters.salePrice.min !== undefined) params.salePriceMin = String(filters.salePrice.min);
-    if (filters.salePrice.max !== undefined) params.salePriceMax = String(filters.salePrice.max);
+    const { mode, min, max } = filters.salePrice;
+    if (mode === '>=' && min !== undefined) {
+      params.salesPrice = String(min);
+      params.salesPriceOperator = 'GE';
+    } else if (mode === '<=' && max !== undefined) {
+      params.salesPrice = String(max);
+      params.salesPriceOperator = 'LE';
+    } else if (mode === 'between') {
+      if (min !== undefined) {
+        params.salesPrice = String(min);
+        params.salesPriceOperator = 'GE';
+      } else if (max !== undefined) {
+        params.salesPrice = String(max);
+        params.salesPriceOperator = 'LE';
+      }
+    }
   }
   if (filters.ratio) {
-    params.ratioMode = filters.ratio.mode;
-    if (filters.ratio.min !== undefined) params.ratioMin = String(filters.ratio.min);
-    if (filters.ratio.max !== undefined) params.ratioMax = String(filters.ratio.max);
+    if (filters.ratio.mode === '>=' && filters.ratio.min !== undefined) {
+      params.ratio = String(filters.ratio.min);
+    } else if (filters.ratio.mode === '<=' && filters.ratio.max !== undefined) {
+      params.ratio = String(filters.ratio.max);
+    } else if (filters.ratio.mode === 'between') {
+      if (filters.ratio.min !== undefined) {
+        params.ratio = String(filters.ratio.min);
+      } else if (filters.ratio.max !== undefined) {
+        params.ratio = String(filters.ratio.max);
+      }
+    }
   }
   if (filters.dwellingType?.length) params.dwellingType = filters.dwellingType.join(',');
   if (filters.flaggedForReview) params.flaggedForReview = filters.flaggedForReview;
-  if (filters.reviewFlags?.length) params.reviewFlags = filters.reviewFlags.join(',');
+  if (filters.reviewFlags?.length) params.reviewFlag = filters.reviewFlags.join(',');
   if (filters.outlierKeySale?.length) params.outlierKeySale = filters.outlierKeySale.join(',');
   if (filters.outlierRatio) {
-    params.outlierRatioMode = filters.outlierRatio.mode;
-    if (filters.outlierRatio.min !== undefined) params.outlierRatioMin = String(filters.outlierRatio.min);
-    if (filters.outlierRatio.max !== undefined) params.outlierRatioMax = String(filters.outlierRatio.max);
+    if (filters.outlierRatio.mode === '>=' && filters.outlierRatio.min !== undefined) {
+      params.outlierRatio = String(filters.outlierRatio.min);
+    } else if (filters.outlierRatio.mode === '<=' && filters.outlierRatio.max !== undefined) {
+      params.outlierRatio = String(filters.outlierRatio.max);
+    } else if (filters.outlierRatio.mode === 'between') {
+      if (filters.outlierRatio.min !== undefined) {
+        params.outlierRatio = String(filters.outlierRatio.min);
+      } else if (filters.outlierRatio.max !== undefined) {
+        params.outlierRatio = String(filters.outlierRatio.max);
+      }
+    }
   }
   if (filters.overallFlag?.length) params.overallFlag = filters.overallFlag.join(',');
   if (filters.summaryFlag) params.summaryFlag = filters.summaryFlag;
   if (filters.taskStatus?.length) params.taskStatus = filters.taskStatus.join(',');
   if (filters.assignedTo) params.assignedTo = filters.assignedTo;
   if (filters.assignedDate) {
-    if (filters.assignedDate.from) params.assignedDateFrom = filters.assignedDate.from;
-    if (filters.assignedDate.to) params.assignedDateTo = filters.assignedDate.to;
+    if (filters.assignedDate.from) params.assignedFromDate = filters.assignedDate.from;
+    if (filters.assignedDate.to) params.assignedToDate = filters.assignedDate.to;
   }
   if (filters.qcAssignedTo) params.qcAssignedTo = filters.qcAssignedTo;
   if (filters.qcAssignedDate) {
-    if (filters.qcAssignedDate.from) params.qcAssignedDateFrom = filters.qcAssignedDate.from;
-    if (filters.qcAssignedDate.to) params.qcAssignedDateTo = filters.qcAssignedDate.to;
+    if (filters.qcAssignedDate.from) params.qcAssignedFromDate = filters.qcAssignedDate.from;
+    if (filters.qcAssignedDate.to) params.qcAssignedToDate = filters.qcAssignedDate.to;
   }
   if (filters.qcCompletedDate) {
-    if (filters.qcCompletedDate.from) params.qcCompletedDateFrom = filters.qcCompletedDate.from;
-    if (filters.qcCompletedDate.to) params.qcCompletedDateTo = filters.qcCompletedDate.to;
-  }
-  if (filters.completedDate) {
-    if (filters.completedDate.from) params.completedDateFrom = filters.completedDate.from;
-    if (filters.completedDate.to) params.completedDateTo = filters.completedDate.to;
+    if (filters.qcCompletedDate.from) params.qcCompleteFromDate = filters.qcCompletedDate.from;
+    if (filters.qcCompletedDate.to) params.qcCompleteToDate = filters.qcCompletedDate.to;
   }
 
   return params;

--- a/DetailsListVOA/data/TaskSearchSample.ts
+++ b/DetailsListVOA/data/TaskSearchSample.ts
@@ -1,4 +1,5 @@
 export interface TaskSearchItem {
+    saleId?: string;
     uprn: string;
     taskId: string;
     taskStatus: string;
@@ -7,6 +8,21 @@ export interface TaskSearchItem {
     postcode: string;
     transactionDate: string;
     source: string;
+    billingAuthority?: string;
+    salesPrice?: number;
+    ratio?: number;
+    dwellingType?: string;
+    flaggedForReview?: boolean;
+    reviewFlags?: string[];
+    outlierRatio?: number;
+    overallFlag?: string;
+    summaryFlags?: string[];
+    assignedTo?: string[] | string;
+    assignedDate?: string;
+    taskCompletedDate?: string;
+    qcAssignedTo?: string[] | string;
+    qcAssignedDate?: string;
+    qcCompletedDate?: string;
 }
 
 export interface TaskSearchResponse {

--- a/DetailsListVOA/services/CustomApi.ts
+++ b/DetailsListVOA/services/CustomApi.ts
@@ -1,0 +1,74 @@
+import { IInputs } from '../generated/ManifestTypes';
+
+interface WebApiExecutor {
+  execute?: (req: unknown) => Promise<Response>;
+}
+
+interface XrmLike {
+  WebApi?: {
+    execute?: (req: unknown) => Promise<Response>;
+    online?: { execute?: (req: unknown) => Promise<Response> };
+  };
+}
+
+const getWebApiExecutor = (context: ComponentFramework.Context<IInputs>): WebApiExecutor => {
+  const webApi = (context as unknown as { webAPI?: WebApiExecutor }).webAPI;
+  if (webApi?.execute) return webApi;
+  const xrm = (globalThis as unknown as { Xrm?: XrmLike }).Xrm;
+  if (xrm?.WebApi?.online?.execute) {
+    return xrm.WebApi.online;
+  }
+  if (xrm?.WebApi?.execute) {
+    return xrm.WebApi;
+  }
+  return {};
+};
+
+export const buildUnboundCustomApiRequest = (
+  operationName: string,
+  params: Record<string, string>,
+): Record<string, unknown> & {
+  getMetadata: () => {
+    boundParameter: null;
+    parameterTypes: Record<string, { typeName: string; structuralProperty: number }>;
+    operationType: number;
+    operationName: string;
+  };
+} => {
+  const request: Record<string, unknown> & {
+    getMetadata: () => {
+      boundParameter: null;
+      parameterTypes: Record<string, { typeName: string; structuralProperty: number }>;
+      operationType: number;
+      operationName: string;
+    };
+  } = {
+    getMetadata: () => ({
+      boundParameter: null,
+      parameterTypes: Object.keys(params).reduce((acc, key) => {
+        acc[key] = { typeName: 'Edm.String', structuralProperty: 1 };
+        return acc;
+      }, {} as Record<string, { typeName: string; structuralProperty: number }>),
+      operationType: 0,
+      operationName,
+    }),
+  };
+  Object.entries(params).forEach(([key, value]) => {
+    request[key] = value;
+  });
+  return request;
+};
+
+export const executeUnboundCustomApi = async <T>(
+  context: ComponentFramework.Context<IInputs>,
+  operationName: string,
+  params: Record<string, string>,
+): Promise<T> => {
+  const executor = getWebApiExecutor(context);
+  if (!executor.execute) {
+    throw new Error('Web API execute is not available in this environment');
+  }
+  const request = buildUnboundCustomApiRequest(operationName, params);
+  const result = await executor.execute(request);
+  return (await result.json()) as T;
+};

--- a/DetailsListVOA/services/DataService.ts
+++ b/DetailsListVOA/services/DataService.ts
@@ -3,6 +3,7 @@ import { GridFilterState } from '../Filters';
 import { buildApiParamsFor } from '../config/TableConfigs';
 import { CONTROL_CONFIG } from '../config/ControlConfig';
 import { TaskSearchItem, TaskSearchResponse } from '../data/TaskSearchSample';
+import { executeUnboundCustomApi } from './CustomApi';
 
 export interface SearchRequest {
   tableKey: string;
@@ -11,24 +12,82 @@ export interface SearchRequest {
   filters: GridFilterState;
 }
 
-async function executeCustomApi(
-  context: ComponentFramework.Context<IInputs>,
-  request: unknown,
-): Promise<Response> {
-  const webApi = (context as unknown as { webAPI?: { execute?: (req: unknown) => Promise<Response> } }).webAPI;
-  if (webApi?.execute) {
-    return webApi.execute(request);
-  }
-  interface XrmLike { WebApi?: { execute?: (req: unknown) => Promise<Response>; online?: { execute?: (req: unknown) => Promise<Response> } } }
-  const xrm = (globalThis as unknown as { Xrm?: XrmLike }).Xrm;
-  if (xrm?.WebApi?.online?.execute) {
-    return xrm.WebApi.online.execute(request);
-  }
-  if (xrm?.WebApi?.execute) {
-    return xrm.WebApi.execute(request);
-  }
-  throw new Error('Web API execute is not available in this environment');
+interface SalesPageInfo {
+  pageNumber?: number;
+  pageSize?: number;
+  totalRecords?: number;
 }
+
+interface SalesApiItem {
+  saleId?: string;
+  taskId?: string;
+  uprn?: string;
+  address?: string;
+  postcode?: string;
+  billingAuthority?: string;
+  transactionDate?: string;
+  salesPrice?: number;
+  ratio?: number;
+  dwellingType?: string;
+  flaggedForReview?: boolean;
+  reviewFlags?: string[];
+  outlierRatio?: number;
+  overallFlag?: string;
+  summaryFlags?: string[];
+  taskStatus?: string;
+  assignedTo?: string[] | string;
+  assignedDate?: string | null;
+  taskCompletedDate?: string | null;
+  qcAssignedTo?: string[] | string;
+  qcAssignedDate?: string | null;
+  qcCompletedDate?: string | null;
+  source?: string;
+}
+
+interface SalesApiResponse {
+  pageInfo?: SalesPageInfo;
+  sales?: SalesApiItem[];
+}
+
+const normalizeSalesItem = (item: SalesApiItem): TaskSearchItem => ({
+  saleId: item.saleId,
+  taskId: item.taskId ?? '',
+  uprn: item.uprn ?? '',
+  taskStatus: item.taskStatus ?? '',
+  caseAssignedTo: Array.isArray(item.assignedTo) ? item.assignedTo.join(', ') : item.assignedTo ?? '',
+  address: item.address ?? '',
+  postcode: item.postcode ?? '',
+  transactionDate: item.transactionDate ?? '',
+  source: item.source ?? '',
+  billingAuthority: item.billingAuthority,
+  salesPrice: item.salesPrice,
+  ratio: item.ratio,
+  dwellingType: item.dwellingType,
+  flaggedForReview: item.flaggedForReview,
+  reviewFlags: item.reviewFlags,
+  outlierRatio: item.outlierRatio,
+  overallFlag: item.overallFlag,
+  summaryFlags: item.summaryFlags,
+  assignedTo: item.assignedTo,
+  assignedDate: item.assignedDate ?? undefined,
+  taskCompletedDate: item.taskCompletedDate ?? undefined,
+  qcAssignedTo: item.qcAssignedTo,
+  qcAssignedDate: item.qcAssignedDate ?? undefined,
+  qcCompletedDate: item.qcCompletedDate ?? undefined,
+});
+
+export const normalizeSearchResponse = (payload: TaskSearchResponse | SalesApiResponse): TaskSearchResponse => {
+  if ('sales' in payload || 'pageInfo' in payload) {
+    const sales = payload.sales ?? [];
+    return {
+      items: sales.map(normalizeSalesItem),
+      totalCount: payload.pageInfo?.totalRecords ?? sales.length,
+      page: payload.pageInfo?.pageNumber ?? 1,
+      pageSize: payload.pageInfo?.pageSize ?? sales.length,
+    };
+  }
+  return payload as TaskSearchResponse;
+};
 
 export async function executeSearch(
   context: ComponentFramework.Context<IInputs>,
@@ -42,33 +101,9 @@ export async function executeSearch(
 
   const customApiName = CONTROL_CONFIG.customApiName;
   if (customApiName?.trim()) {
-    // Build an unbound Custom API request with string parameters
     const actionName = customApiName.trim();
-    const request: Record<string, unknown> & {
-      getMetadata: () => {
-        boundParameter: null;
-        parameterTypes: Record<string, { typeName: string; structuralProperty: number }>;
-        operationType: number;
-        operationName: string;
-      };
-    } = {
-      getMetadata: () => ({
-        boundParameter: null,
-        parameterTypes: Object.keys(apiParams).reduce((acc, key) => {
-          acc[key] = { typeName: 'Edm.String', structuralProperty: 1 };
-          return acc;
-        }, {} as Record<string, { typeName: string; structuralProperty: number }>),
-        operationType: 0, // Action
-        operationName: actionName,
-      }),
-    };
-    Object.entries(apiParams).forEach(([k, v]) => {
-      (request as Record<string, unknown>)[k] = v;
-    });
-
-    const result = await executeCustomApi(context, request);
-    const payload = (await result.json()) as TaskSearchResponse;
-    return payload;
+    const payload = await executeUnboundCustomApi<TaskSearchResponse | SalesApiResponse>(context, actionName, apiParams);
+    return normalizeSearchResponse(payload);
   }
 
   const url = new URL(baseUrl);
@@ -77,8 +112,8 @@ export async function executeSearch(
   if (!response.ok) {
     throw new Error(`APIM request failed with status ${response.status}`);
   }
-  const payload = (await response.json()) as TaskSearchResponse;
-  return payload;
+  const payload = (await response.json()) as TaskSearchResponse | SalesApiResponse;
+  return normalizeSearchResponse(payload);
 }
 
 export interface FilterOptionsRequest {
@@ -99,32 +134,8 @@ export async function fetchFilterOptions(
   if ((customApiName ?? '').trim().length > 0) {
     // Unbound Custom API variant for filter suggestions
     const actionName = `${customApiName?.trim()}_FilterOptions`;
-    const request: Record<string, unknown> & {
-      getMetadata: () => {
-        boundParameter: null;
-        parameterTypes: Record<string, { typeName: string; structuralProperty: number }>;
-        operationType: number;
-        operationName: string;
-      };
-    } = {
-      getMetadata: () => ({
-        boundParameter: null,
-        parameterTypes: {
-          tableKey: { typeName: 'Edm.String', structuralProperty: 1 },
-          field: { typeName: 'Edm.String', structuralProperty: 1 },
-          query: { typeName: 'Edm.String', structuralProperty: 1 },
-        },
-        operationType: 0,
-        operationName: actionName,
-      }),
-    };
-    (request as Record<string, unknown>).tableKey = tableKey;
-    (request as Record<string, unknown>).field = field;
-    (request as Record<string, unknown>).query = query;
-
     try {
-      const resp = await executeCustomApi(context, request);
-      const payload = (await resp.json()) as { values?: string[] };
+      const payload = await executeUnboundCustomApi<{ values?: string[] }>(context, actionName, { tableKey, field, query });
       return payload.values ?? [];
     } catch {
       return [];
@@ -172,6 +183,8 @@ export function mapTaskItemToRecord(
   record.uprn = item.uprn;
   record.taskid = item.taskId;
   record.taskId = item.taskId;
+  record.saleid = item.saleId ?? '';
+  record.saleId = item.saleId ?? '';
   record.taskstatus = item.taskStatus;
   record.taskStatus = item.taskStatus;
   record.caseassignedto = item.caseAssignedTo;
@@ -181,7 +194,23 @@ export function mapTaskItemToRecord(
   record.transactiondate = formattedDate;
   record.transactionDate = formattedDate;
   record.source = item.source;
-  record.saleId = '';
+  record.billingauthority = item.billingAuthority ?? '';
+  record.billingAuthority = item.billingAuthority ?? '';
+  record.saleprice = item.salesPrice ?? '';
+  record.salesPrice = item.salesPrice ?? '';
+  record.ratio = item.ratio ?? '';
+  record.dwellingtype = item.dwellingType ?? '';
+  record.flaggedforreview = item.flaggedForReview ?? '';
+  record.reviewflags = item.reviewFlags ?? [];
+  record.outlierratio = item.outlierRatio ?? '';
+  record.overallflag = item.overallFlag ?? '';
+  record.summaryflags = item.summaryFlags ?? [];
+  record.assignedto = item.assignedTo ?? '';
+  record.assigneddate = item.assignedDate ?? '';
+  record.taskcompleteddate = item.taskCompletedDate ?? '';
+  record.qcassignedto = item.qcAssignedTo ?? '';
+  record.qcassigneddate = item.qcAssignedDate ?? '';
+  record.qccompleteddate = item.qcCompletedDate ?? '';
   return record;
 }
 

--- a/DetailsListVOA/services/GridDataController.ts
+++ b/DetailsListVOA/services/GridDataController.ts
@@ -3,6 +3,8 @@ import { CONTROL_CONFIG } from '../config/ControlConfig';
 import { TaskSearchItem, TaskSearchResponse } from '../data/TaskSearchSample';
 import { SAMPLE_RECORDS } from '../data/SampleData';
 import { IInputs } from '../generated/ManifestTypes';
+import { executeUnboundCustomApi } from './CustomApi';
+import { normalizeSearchResponse } from './DataService';
 
 export interface ClientSortState {
   name: string;
@@ -41,12 +43,11 @@ const getPrefilterParams = (context: ComponentFramework.Context<IInputs>): Recor
     }
   };
   const result: Record<string, string> = {};
-  addIfPresent(result, 'searchBy', normalizeText(params.searchBy?.raw));
-  addIfPresent(result, 'billingAuthorities', normalizeMulti(params.billingAuthorities?.raw));
-  addIfPresent(result, 'caseworkers', normalizeMulti(params.caseworkers?.raw));
-  addIfPresent(result, 'workThat', normalizeText(params.workThat?.raw));
-  addIfPresent(result, 'fromDate', normalizeText(params.fromDate?.raw));
-  addIfPresent(result, 'toDate', normalizeText(params.toDate?.raw));
+  addIfPresent(result, 'billingAuthority', normalizeMulti(params.billingAuthorities?.raw));
+  addIfPresent(result, 'assignedTo', normalizeMulti(params.caseworkers?.raw));
+  addIfPresent(result, 'taskStatus', normalizeMulti(params.workThat?.raw));
+  addIfPresent(result, 'assignedFromDate', normalizeText(params.fromDate?.raw));
+  addIfPresent(result, 'assignedToDate', normalizeText(params.toDate?.raw));
   return result;
 };
 
@@ -89,42 +90,21 @@ export async function loadGridData(
     const p: Record<string, string> = {
       ...apiParamsBase,
       ...prefilterParams,
-      page: String(page),
+      pageNumber: String(page + 1),
       pageSize: String(pageSize),
     };
-    if (sortBy) p.sortBy = sortBy;
-    if (typeof sortDirection === 'number') p.sortDirection = String(sortDirection);
+    if (sortBy) p.sortField = sortBy;
+    if (typeof sortDirection === 'number') p.sortDirection = sortDirection === 1 ? 'desc' : 'asc';
     return p;
   };
 
   const execCustomApi = async (params: Record<string, string>): Promise<TaskSearchResponse> => {
-    const request: Record<string, unknown> & {
-      getMetadata: () => {
-        boundParameter: null;
-        parameterTypes: Record<string, { typeName: string; structuralProperty: number }>;
-        operationType: number;
-        operationName: string;
-      };
-    } = {
-      getMetadata: () => ({
-        boundParameter: null,
-        parameterTypes: Object.keys(params).reduce((acc, key) => {
-          acc[key] = { typeName: 'Edm.String', structuralProperty: 1 };
-          return acc;
-        }, {} as Record<string, { typeName: string; structuralProperty: number }>),
-        operationType: 0,
-        operationName: customApiName ?? '',
-      }),
+    const withFilters = {
+      ...params,
+      ...(headerFilterEntries.length > 0 ? { columnFilters: JSON.stringify(args.headerFilters) } : {}),
     };
-    Object.entries(params).forEach(([k, v]) => {
-      request[k] = v;
-    });
-    if (headerFilterEntries.length > 0) {
-      request.columnFilters = JSON.stringify(args.headerFilters);
-    }
-    interface WebApiWithExecute { execute: (request: unknown) => Promise<Response>; }
-    const result = await (context.webAPI as unknown as WebApiWithExecute).execute(request);
-    return (await result.json()) as TaskSearchResponse;
+    const payload = await executeUnboundCustomApi<TaskSearchResponse>(context, customApiName ?? '', withFilters);
+    return normalizeSearchResponse(payload);
   };
 
   const execHttp = async (params: Record<string, string>): Promise<TaskSearchResponse> => {
@@ -144,7 +124,8 @@ export async function loadGridData(
     }
     const response = await fetch(url.toString(), { method: 'GET' });
     if (!response.ok) throw new Error(`APIM request failed with status ${response.status}`);
-    return (await response.json()) as TaskSearchResponse;
+    const payload = (await response.json()) as TaskSearchResponse;
+    return normalizeSearchResponse(payload);
   };
 
   try {


### PR DESCRIPTION
### Motivation
- Replace direct task-oriented APIM calls with the sales-focused `/sales` endpoint and the `svtGetSaleRecords` unbound custom API for PCF data loading.
- Align PCF filter keys and UI values with the APIM parameter contract (paging, sort, sales price operators and boolean filters).
- Provide reusable helpers to invoke Dynamics unbound custom actions from the PCF control so the plugin/callers can reuse the logic.

### Description
- Added `DetailsListVOA/services/CustomApi.ts` with `buildUnboundCustomApiRequest` and `executeUnboundCustomApi` to encapsulate unbound custom API execution via `webAPI.execute`/`Xrm.WebApi`.
- Updated `CONTROL_CONFIG` to target `https://api.contoso.gov.uk/revaluation/sales` and set `customApiName` to `svtGetSaleRecords` so the PCF uses the sales custom API by default.
- Mapped and renamed filter parameters in `config/TableConfigs.ts` (e.g. `pageNumber`, `billingAuthority`, `billingAuthorityReference`, `salesPrice` + `salesPriceOperator`, `transactionDate`, `reviewFlag`, `assignedFromDate`/`assignedToDate`, `qcAssignedFromDate`/`qcAssignedToDate`, `qcCompleteFromDate`/`qcCompleteToDate`) and changed `flaggedForReview` values to `'true' | 'false'` across `Filters.ts` and `Grid.tsx`.
- Normalized API responses in `services/DataService.ts` (added `SalesApiResponse`/`SalesApiItem` types and `normalizeSearchResponse`) and updated `GridDataController.ts` to use the new `executeUnboundCustomApi` path, map paging/sorting to `pageNumber`/`sortField`/`sortDirection`, and merge header/prefilter params for custom API calls.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe43d1040832c81eeaf52efa00ddc)