### PR TITLE
Use `svtGetSaleRecords` only and remove APIM/http fallback

### DIFF
--- a/DetailsListVOA/config/ControlConfig.ts
+++ b/DetailsListVOA/config/ControlConfig.ts
@@ -1,6 +1,5 @@
 export const CONTROL_CONFIG = {
   apiBaseUrl: '',
-  apimEndpoint: 'https://api.contoso.gov.uk/revaluation/sales',
   customApiName: 'svtGetSaleRecords',
   tableKey: 'sales',
 };

--- a/DetailsListVOA/services/DataService.ts
+++ b/DetailsListVOA/services/DataService.ts
@@ -2,7 +2,7 @@ import { IInputs } from '../generated/ManifestTypes';
 import { GridFilterState } from '../Filters';
 import { buildApiParamsFor } from '../config/TableConfigs';
 import { CONTROL_CONFIG } from '../config/ControlConfig';
-import { TaskSearchItem, TaskSearchResponse } from '../data/TaskSearchSample';
+import { TaskSearchItem, TaskSearchResponse, SAMPLE_TASK_RESULTS } from '../data/TaskSearchSample';
 import { executeUnboundCustomApi } from './CustomApi';
 
 export interface SearchRequest {
@@ -94,26 +94,30 @@ export async function executeSearch(
   req: SearchRequest,
 ): Promise<TaskSearchResponse> {
   const { tableKey, page, pageSize, filters } = req;
-  const ep = CONTROL_CONFIG.apimEndpoint ?? '';
-  const baseUrl = ep.trim().length > 0 ? ep : 'https://api.contoso.gov.uk/revaluation/tasks';
 
   const apiParams = buildApiParamsFor(tableKey, filters, page, pageSize);
 
-  const customApiName = CONTROL_CONFIG.customApiName;
-  if (customApiName?.trim()) {
-    const actionName = customApiName.trim();
-    const payload = await executeUnboundCustomApi<TaskSearchResponse | SalesApiResponse>(context, actionName, apiParams);
-    return normalizeSearchResponse(payload);
+  const customApiName = CONTROL_CONFIG.customApiName?.trim() ?? '';
+  if (!customApiName) {
+    return {
+      items: SAMPLE_TASK_RESULTS,
+      totalCount: SAMPLE_TASK_RESULTS.length,
+      page,
+      pageSize,
+    };
   }
 
-  const url = new URL(baseUrl);
-  Object.entries(apiParams).forEach(([k, v]) => url.searchParams.set(k, v));
-  const response = await fetch(url.toString(), { method: 'GET' });
-  if (!response.ok) {
-    throw new Error(`APIM request failed with status ${response.status}`);
+  try {
+    const payload = await executeUnboundCustomApi<TaskSearchResponse | SalesApiResponse>(context, customApiName, apiParams);
+    return normalizeSearchResponse(payload);
+  } catch {
+    return {
+      items: SAMPLE_TASK_RESULTS,
+      totalCount: SAMPLE_TASK_RESULTS.length,
+      page,
+      pageSize,
+    };
   }
-  const payload = (await response.json()) as TaskSearchResponse | SalesApiResponse;
-  return normalizeSearchResponse(payload);
 }
 
 export interface FilterOptionsRequest {
@@ -127,31 +131,12 @@ export async function fetchFilterOptions(
   req: FilterOptionsRequest,
 ): Promise<string[]> {
   const { tableKey, field, query } = req;
-  const ep = CONTROL_CONFIG.apimEndpoint ?? '';
-  const baseUrl = ep.trim().length > 0 ? ep : 'https://api.contoso.gov.uk/revaluation/tasks';
-
-  const customApiName = CONTROL_CONFIG.customApiName;
-  if ((customApiName ?? '').trim().length > 0) {
-    // Unbound Custom API variant for filter suggestions
-    const actionName = `${customApiName?.trim()}_FilterOptions`;
-    try {
-      const payload = await executeUnboundCustomApi<{ values?: string[] }>(context, actionName, { tableKey, field, query });
-      return payload.values ?? [];
-    } catch {
-      return [];
-    }
-  }
-
+  const customApiName = CONTROL_CONFIG.customApiName?.trim() ?? '';
+  if (!customApiName) return [];
+  // Unbound Custom API variant for filter suggestions
+  const actionName = `${customApiName}_FilterOptions`;
   try {
-    const url = new URL(baseUrl.replace(/\/?$/, '/')); // ensure trailing slash
-    // Expect an endpoint like: GET /filterOptions?tableKey=...&field=...&query=...
-    url.pathname = `${url.pathname.replace(/\/$/, '')}/filterOptions`;
-    url.searchParams.set('tableKey', tableKey);
-    url.searchParams.set('field', field);
-    url.searchParams.set('query', query);
-    const res = await fetch(url.toString(), { method: 'GET' });
-    if (!res.ok) return [];
-    const payload = (await res.json()) as { values?: string[] };
+    const payload = await executeUnboundCustomApi<{ values?: string[] }>(context, actionName, { tableKey, field, query });
     return payload.values ?? [];
   } catch {
     return [];

--- a/DetailsListVOA/services/GridDataController.ts
+++ b/DetailsListVOA/services/GridDataController.ts
@@ -1,7 +1,7 @@
 import { buildApiParamsFor } from '../config/TableConfigs';
 import { CONTROL_CONFIG } from '../config/ControlConfig';
 import { TaskSearchItem, TaskSearchResponse } from '../data/TaskSearchSample';
-import { SAMPLE_RECORDS } from '../data/SampleData';
+import { SAMPLE_TASK_RESULTS } from '../data/TaskSearchSample';
 import { IInputs } from '../generated/ManifestTypes';
 import { executeUnboundCustomApi } from './CustomApi';
 import { normalizeSearchResponse } from './DataService';
@@ -62,19 +62,6 @@ export async function loadGridData(
     clientSort?: ClientSortState;
   },
 ): Promise<LoadResult> {
-  const configuredEndpoint = CONTROL_CONFIG.apimEndpoint?.trim();
-  const baseUrl = configuredEndpoint && configuredEndpoint.length > 0
-    ? configuredEndpoint
-    : 'https://api.contoso.gov.uk/revaluation/tasks';
-
-  let requestUrl: URL;
-  try {
-    requestUrl = new URL(baseUrl);
-  } catch {
-    // Fall back to showing local SAMPLE_RECORDS via host's sample path
-    return { items: [], totalCount: SAMPLE_RECORDS.length, serverDriven: false };
-  }
-
   const pageSize = (context.parameters as unknown as Record<string, { raw?: number }>).pageSize?.raw ?? 10;
   const apiParamsBase = buildApiParamsFor(args.tableKey, args.filters as never, args.currentPage, pageSize);
   const prefilterParams = getPrefilterParams(context);
@@ -82,7 +69,7 @@ export async function loadGridData(
     Array.isArray(v) ? v.length > 0 : (v ?? '').toString().trim() !== '',
   );
 
-  const customApiName = CONTROL_CONFIG.customApiName?.trim();
+  const customApiName = CONTROL_CONFIG.customApiName?.trim() ?? '';
 
   const sortBy = args.clientSort?.name;
   const sortDirection = args.clientSort?.sortDirection;
@@ -103,34 +90,16 @@ export async function loadGridData(
       ...params,
       ...(headerFilterEntries.length > 0 ? { columnFilters: JSON.stringify(args.headerFilters) } : {}),
     };
-    const payload = await executeUnboundCustomApi<TaskSearchResponse>(context, customApiName ?? '', withFilters);
-    return normalizeSearchResponse(payload);
-  };
-
-  const execHttp = async (params: Record<string, string>): Promise<TaskSearchResponse> => {
-    const url = new URL(baseUrl);
-    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
-    if (headerFilterEntries.length > 0) {
-      headerFilterEntries.forEach(([field, val]) => {
-        if (Array.isArray(val)) {
-          val.forEach((v) => {
-            if ((v ?? '').toString().trim() !== '') url.searchParams.append(`filter[${field}][]`, String(v));
-          });
-        } else {
-          const trimmed = (val ?? '').toString().trim();
-          if (trimmed !== '') url.searchParams.append(`filter[${field}]`, trimmed);
-        }
-      });
-    }
-    const response = await fetch(url.toString(), { method: 'GET' });
-    if (!response.ok) throw new Error(`APIM request failed with status ${response.status}`);
-    const payload = (await response.json()) as TaskSearchResponse;
+    const payload = await executeUnboundCustomApi<TaskSearchResponse>(context, customApiName, withFilters);
     return normalizeSearchResponse(payload);
   };
 
   try {
     const firstParams = buildParams(args.currentPage);
-    const firstPayload = customApiName ? await execCustomApi(firstParams) : await execHttp(firstParams);
+    if (!customApiName) {
+      return { items: SAMPLE_TASK_RESULTS, totalCount: SAMPLE_TASK_RESULTS.length, serverDriven: false };
+    }
+    const firstPayload = await execCustomApi(firstParams);
     const total = Number(firstPayload.totalCount ?? firstPayload.items?.length ?? 0);
     const serverDriven = total > 2000;
     if (!serverDriven && total > 0 && (firstPayload.items?.length ?? 0) < total) {
@@ -138,14 +107,13 @@ export async function loadGridData(
       const all: TaskSearchItem[] = [...(firstPayload.items ?? [])];
       for (let p = 0; p < pages; p++) {
         if (p === args.currentPage) continue;
-        const payload = customApiName ? await execCustomApi(buildParams(p)) : await execHttp(buildParams(p));
+        const payload = await execCustomApi(buildParams(p));
         all.push(...(payload.items ?? []));
       }
       return { items: all, totalCount: total, serverDriven: false };
     }
     return { items: firstPayload.items ?? [], totalCount: total, serverDriven };
   } catch {
-    // Fall back to showing local SAMPLE_RECORDS via host's sample path
-    return { items: [], totalCount: SAMPLE_RECORDS.length, serverDriven: false };
+    return { items: SAMPLE_TASK_RESULTS, totalCount: SAMPLE_TASK_RESULTS.length, serverDriven: false };
   }
 }


### PR DESCRIPTION
### Motivation
- Stop calling APIM/HTTP endpoints from the PCF control and rely on the `svtGetSaleRecords` custom API instead.
- Ensure the grid still renders when the custom API is missing or errors by returning a sample response for now.
- Simplify service code paths by removing the APIM URL configuration and HTTP fetch fallback.

### Description
- Removed the `apimEndpoint` entry from `DetailsListVOA/config/ControlConfig.ts` to prevent HTTP/APIM usage.
- Updated `executeSearch` in `DetailsListVOA/services/DataService.ts` to call the configured custom API via `executeUnboundCustomApi` and to return `SAMPLE_TASK_RESULTS` when the custom API name is not set or the call fails.
- Updated `fetchFilterOptions` in `DetailsListVOA/services/DataService.ts` to use the custom API (`<customApi>_FilterOptions`) and removed the HTTP fallback.
- Updated `DetailsListVOA/services/GridDataController.ts` to execute only the custom API path via `executeUnboundCustomApi` and to fall back to `SAMPLE_TASK_RESULTS` on missing configuration or errors, removing the HTTP/APIM logic.

### Testing
- No automated tests were run for these changes.
- TypeScript typing of modified files was preserved by the edits (no runtime test executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe9c14954832c9d8edfad7cbde239)