### PR TITLE
docs: refine svtGetSaleRecords method documentation

### DIFF
--- a/docs/svtGetSaleRecords.md
+++ b/docs/svtGetSaleRecords.md
@@ -1,111 +1,84 @@
 # svtGetSaleRecords Custom API (SVT List)
 
-## Overview
-`svtGetSaleRecords` is an **unbound** Dynamics/Dataverse Custom API invoked by the SVT List PCF control to retrieve sale/task rows for the grid. The control builds a parameter map from the active filters and pagination settings, calls the custom API through `Xrm.WebApi.execute`, and then normalizes the response into the internal `TaskSearchResponse` format for rendering and filtering in the UI.【F:DetailsListVOA/services/CustomApi.ts†L11-L73】【F:DetailsListVOA/services/GridDataController.ts†L62-L123】【F:DetailsListVOA/services/DataService.ts†L73-L188】
+## Purpose
+`svtGetSaleRecords` is an **unbound** Dataverse Custom API used by the SVT List PCF control to load grid rows. The control assembles the current search filters, column header filters, sorting, and paging into a request, executes the API through `Xrm.WebApi.execute`, then normalizes the response into the grid’s `TaskSearchResponse` format for rendering and filter synchronization.【F:DetailsListVOA/services/CustomApi.ts†L11-L73】【F:DetailsListVOA/services/GridDataController.ts†L62-L123】【F:DetailsListVOA/services/DataService.ts†L73-L188】
 
-The configured custom API name is set in the control configuration and defaults to `svtGetSaleRecords` for this repository’s control build.【F:DetailsListVOA/config/ControlConfig.ts†L1-L4】
-
----
-
-## Where it is called (entry points)
-
-### Primary grid load (server-driven paging)
-The grid controller uses the configured API name (`svtGetSaleRecords`) and sends:
-- **Base filter parameters** assembled from the active grid search filters.
-- **Prefilter parameters** mapped from PCF input parameters (e.g., billing authorities, caseworkers, work status, assigned dates).
-- **Column header filter values** serialized as `columnFilters` when the user applies column filters.
-- **Pagination parameters** `pageNumber` (1-based) and `pageSize`.
-- Optional **sorting parameters** `sortField` and `sortDirection`.
-
-This all flows through `loadGridData` → `execCustomApi` → `executeUnboundCustomApi` when `customApiName` is configured.【F:DetailsListVOA/services/GridDataController.ts†L30-L123】【F:DetailsListVOA/services/CustomApi.ts†L53-L73】
-
-### Filter option lookups (typeahead/suggest)
-The control also calls a companion custom API for filter suggestions, using the name `<customApiName>_FilterOptions` (for this repo: `svtGetSaleRecords_FilterOptions`) with `tableKey`, `field`, and `query` parameters.【F:DetailsListVOA/services/DataService.ts†L201-L228】
+The API name is configured in the control config and defaults to `svtGetSaleRecords` for this repo build.【F:DetailsListVOA/config/ControlConfig.ts†L1-L4】
 
 ---
 
-## Input parameters (request)
-The base parameters are built in `buildSalesParams` and emitted via `buildApiParamsFor`. Parameters are **string-valued** when sent to the custom API, consistent with the unbound request metadata built in `buildUnboundCustomApiRequest`.【F:DetailsListVOA/config/TableConfigs.ts†L78-L182】【F:DetailsListVOA/services/CustomApi.ts†L23-L51】
+## Method used to call the API (detailed flow)
+The control calls the API using **`Xrm.WebApi.execute` with an unbound request**. That request is built by `buildUnboundCustomApiRequest` and passed through `executeUnboundCustomApi`.
 
-### Pagination
-| Parameter | Source | Notes |
+### Detailed method flow
+1. **Collect UI state**
+   - The grid host collects search filters, column filters, sorting, and paging from the UI.
+   - Prefilters from PCF input parameters (if configured) are merged into the same parameter set.
+
+2. **Build request parameters**
+   - `loadGridData` generates the base parameter map using `buildApiParamsFor` (table config).【F:DetailsListVOA/services/GridDataController.ts†L62-L123】【F:DetailsListVOA/config/TableConfigs.ts†L78-L212】
+   - Each parameter is stringified, because unbound custom API parameters are sent as strings in the metadata built by `buildUnboundCustomApiRequest`.【F:DetailsListVOA/services/CustomApi.ts†L23-L51】
+
+3. **Create the unbound API request**
+   - `executeUnboundCustomApi` calls `buildUnboundCustomApiRequest` to create the request object:
+     - `getMetadata()` specifies **`boundParameter: null`** (unbound), **`parameterTypes`**, and **`operationName`** (the custom API name).
+     - The request object includes the parameter map built in step 2.
+
+4. **Execute via `Xrm.WebApi.execute`**
+   - The request object is passed to `Xrm.WebApi.execute` and the response is read as JSON.
+   - The response is then normalized in `DataService` to the internal `TaskSearchResponse` shape.
+
+Key method chain:
+- `GridDataController.loadGridData` → `GridDataController.execCustomApi`
+- `CustomApi.executeUnboundCustomApi` → `CustomApi.buildUnboundCustomApiRequest` → `Xrm.WebApi.execute`
+
+【F:DetailsListVOA/services/GridDataController.ts†L62-L123】【F:DetailsListVOA/services/CustomApi.ts†L23-L73】
+
+---
+
+## How parameters are passed
+All parameters are sent as **string values** in the unbound custom API request. The control builds the parameter object using table config mappings and current UI filter state.
+
+### Pagination and sorting
+| Parameter | How it’s set | Notes |
 | --- | --- | --- |
-| `pageNumber` | current page index | 1-based page number (`page + 1`).【F:DetailsListVOA/config/TableConfigs.ts†L83-L88】 |
-| `pageSize` | grid page size | Numeric string from grid paging configuration.【F:DetailsListVOA/config/TableConfigs.ts†L83-L88】 |
+| `pageNumber` | `page + 1` | 1-based page index. 【F:DetailsListVOA/config/TableConfigs.ts†L83-L88】 |
+| `pageSize` | grid page size | Stringified number. 【F:DetailsListVOA/config/TableConfigs.ts†L83-L88】 |
+| `sortField` | current sort column | Optional. 【F:DetailsListVOA/services/GridDataController.ts†L69-L102】 |
+| `sortDirection` | `asc` / `desc` | Optional. 【F:DetailsListVOA/services/GridDataController.ts†L69-L102】 |
 
-### Search & filter parameters
-Below are the **filter-to-parameter mappings** the control sends to `svtGetSaleRecords`.
+### Top-of-grid filters
+The main search filters are sanitized and mapped into API parameters before being passed to the API (trimmed, validated, or normalized).【F:DetailsListVOA/Filters.ts†L70-L231】
 
-> **Top search filters** are sanitized before mapping (trimmed, minimum length enforced, and numeric/date filters validated).【F:DetailsListVOA/Filters.ts†L70-L231】
+Examples of mappings:
+- `saleId`, `taskId`, `uprn`, `address`, `postcode`, `billingAuthority`, etc.
+- Range filters like `salesPrice`, `ratio`, `outlierRatio` emit a value plus operator (`GE`/`LE`) where applicable.
 
-#### Identity and address filters
-- `source` ← `filters.source`
-- `saleId` ← `filters.saleId`
-- `taskId` ← `filters.taskId`
-- `uprn` ← `filters.uprn` (digits-only normalization)
-- `address` ← `filters.address`
-- `buildingNameOrNumber` ← `filters.buildingNameNumber`
-- `street` ← `filters.street`
-- `town` ← `filters.townCity`
-- `postcode` ← `filters.postcode`
-- `billingAuthority` ← `filters.billingAuthority` (comma-joined array, max 3)
-- `billingAuthorityReference` ← `filters.bacode`
-
-【F:DetailsListVOA/Filters.ts†L70-L231】【F:DetailsListVOA/config/TableConfigs.ts†L90-L120】
-
-#### Transaction date
-- `transactionDate` ← `filters.transactionDate` (uses the provided `from`/`to` value as a single date string; if both present, `from` is used).【F:DetailsListVOA/config/TableConfigs.ts†L120-L141】
-
-#### Sale price
-- `salesPrice` ← numeric value from `filters.salePrice` (min or max, depending on mode)
-- `salesPriceOperator` ← `GE` (>=) or `LE` (<=)
-
-For `between`, the min value (if present) wins; otherwise the max value is used. The custom API should interpret `salesPrice` + `salesPriceOperator` accordingly.【F:DetailsListVOA/config/TableConfigs.ts†L142-L160】
-
-#### Ratio & outlier ratio
-- `ratio` ← numeric value from `filters.ratio` (min/max depending on mode)
-- `outlierRatio` ← numeric value from `filters.outlierRatio` (min/max depending on mode)
-
-For `between`, the min value (if present) is used; otherwise the max value is used.【F:DetailsListVOA/config/TableConfigs.ts†L161-L196】
-
-#### Status, flags, and assignments
-- `dwellingType` ← `filters.dwellingType` (comma-joined)
-- `flaggedForReview` ← `filters.flaggedForReview`
-- `reviewFlag` ← `filters.reviewFlags` (comma-joined)
-- `outlierKeySale` ← `filters.outlierKeySale` (comma-joined)
-- `overallFlag` ← `filters.overallFlag` (comma-joined)
-- `summaryFlag` ← `filters.summaryFlag`
-- `taskStatus` ← `filters.taskStatus` (comma-joined)
-- `assignedTo` ← `filters.assignedTo`
-- `assignedFromDate`/`assignedToDate` ← `filters.assignedDate`
-- `qcAssignedTo` ← `filters.qcAssignedTo`
-- `qcAssignedFromDate`/`qcAssignedToDate` ← `filters.qcAssignedDate`
-- `qcCompleteFromDate`/`qcCompleteToDate` ← `filters.qcCompletedDate`
-
-【F:DetailsListVOA/Filters.ts†L148-L231】【F:DetailsListVOA/config/TableConfigs.ts†L165-L212】
+The actual parameter names are defined in `buildSalesParams` and returned by `buildApiParamsFor`.【F:DetailsListVOA/config/TableConfigs.ts†L78-L212】
 
 ### Prefilter parameters from PCF inputs
-When defined on the component, the following input parameters are passed along to the API:
+If the component is configured with prefilters (input parameters on the PCF control), those values are normalized and passed through:
 - `billingAuthorities` → `billingAuthority`
 - `caseworkers` → `assignedTo`
 - `workThat` → `taskStatus`
 - `fromDate` → `assignedFromDate`
 - `toDate` → `assignedToDate`
 
-These can be raw strings or JSON arrays, and are normalized to comma-separated values before being passed to the API.【F:DetailsListVOA/services/GridDataController.ts†L19-L57】
+Raw strings or JSON arrays are normalized to comma-separated values before being sent to the API.【F:DetailsListVOA/services/GridDataController.ts†L19-L57】
 
 ### Column header filters
 When column filters are applied in the grid header, they are sent as:
 - `columnFilters` → JSON string of `{ [columnName]: value | value[] | object }`
 
-The API can use this to apply precise column-level constraints beyond the top-of-grid filters.【F:DetailsListVOA/services/GridDataController.ts†L69-L102】
+This lets the API apply precise column-level constraints beyond top-of-grid filters.【F:DetailsListVOA/services/GridDataController.ts†L69-L102】
 
 ---
 
-## Response shape (expected from svtGetSaleRecords)
-The control expects **either** a `TaskSearchResponse` payload **or** a `SalesApiResponse` payload. If `sales` or `pageInfo` exist, the response is normalized into `TaskSearchResponse` before being returned to the grid.【F:DetailsListVOA/services/DataService.ts†L146-L164】
+## How the response is mapped
+The control accepts two response shapes and normalizes them into `TaskSearchResponse`.
 
-### Option A: TaskSearchResponse (already normalized)
+### Accepted response shapes
+**Option A: TaskSearchResponse (already normalized)**
 ```
 {
   items: TaskSearchItem[];
@@ -116,7 +89,7 @@ The control expects **either** a `TaskSearchResponse` payload **or** a `SalesApi
 }
 ```
 
-### Option B: SalesApiResponse (normalized by the client)
+**Option B: SalesApiResponse (normalized by the client)**
 ```
 {
   pageInfo?: {
@@ -129,48 +102,27 @@ The control expects **either** a `TaskSearchResponse` payload **or** a `SalesApi
 }
 ```
 
-When the `SalesApiResponse` shape is used, each item in `sales` is transformed into the internal `TaskSearchItem` with the following key mappings:
-- `saleId` → `saleId`
-- `taskId` → `taskId`
-- `uprn` → `uprn`
-- `address` → `address`
-- `postcode` → `postcode`
-- `billingAuthority` → `billingAuthority`
-- `transactionDate` → `transactionDate`
-- `salesPrice` → `salesPrice`
-- `ratio` → `ratio`
-- `dwellingType` → `dwellingType`
-- `flaggedForReview` → `flaggedForReview`
-- `reviewFlags` → `reviewFlags`
-- `outlierRatio` → `outlierRatio`
-- `overallFlag` → `overallFlag`
-- `summaryFlags` → `summaryFlags`
-- `taskStatus` → `taskStatus`
-- `assignedTo` → `assignedTo` (arrays are joined into a display string for `caseAssignedTo`)
-- `assignedDate` → `assignedDate`
-- `taskCompletedDate` → `taskCompletedDate`
-- `qcAssignedTo` → `qcAssignedTo`
-- `qcAssignedDate` → `qcAssignedDate`
-- `qcCompletedDate` → `qcCompletedDate`
-- `source` → `source`
+If `sales` or `pageInfo` exist, the control maps them into `TaskSearchResponse` before returning to the grid.【F:DetailsListVOA/services/DataService.ts†L146-L164】
 
-【F:DetailsListVOA/services/DataService.ts†L94-L144】
+### Item field mapping
+When the API returns `sales`, each item is mapped into the internal `TaskSearchItem`. The mapping is one-to-one (e.g., `saleId` → `saleId`, `taskStatus` → `taskStatus`, etc.).【F:DetailsListVOA/services/DataService.ts†L94-L144】
 
-The `pageInfo` object is mapped to `totalCount`, `page`, and `pageSize` for grid consumption.【F:DetailsListVOA/services/DataService.ts†L146-L162】
+### Page info mapping
+`pageInfo.totalRecords`, `pageInfo.pageNumber`, and `pageInfo.pageSize` are mapped to `totalCount`, `page`, and `pageSize` for the grid.【F:DetailsListVOA/services/DataService.ts†L146-L162】
 
 ---
 
-## Response filters and how they drive the grid
-The API can return a `filters` object to pre-populate or synchronize the grid’s column filter state. The client:
-1. Lowercases each returned filter key.
-2. Accepts arrays, strings (including JSON-encoded arrays/objects), or object shapes.
-3. Converts values into column filter values for the grid header controls.
+## How response filters map to column header filters
+The API can return a `filters` object that directly seeds or syncs the grid’s column header filters. The grid host:
+1. Lowercases each filter key.
+2. Accepts arrays, strings (including JSON-encoded arrays/objects), or object values.
+3. Converts those values into the grid’s column filter state used by header filter controls.
 
-This mapping is handled by `normalizeApiFilters` in the grid host component.【F:DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx†L52-L112】
+This normalization happens in `normalizeApiFilters` inside the grid host component.【F:DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx†L52-L112】
 
-**Guidance for the API:**
-- Use lowercased field names (e.g., `saleid`, `saleprice`, `taskstatus`) to align with the grid’s column keys.
-- You may send arrays or JSON strings for multi-select filters; both are accepted.
-- When sending numeric/date range filters, supply the value as a JSON object (e.g., `{ "mode": ">=", "min": 100000 }` for numeric) and the UI will parse it.
+### Practical guidance for API responses
+- Prefer **lowercased** field names (e.g., `saleid`, `saleprice`, `taskstatus`) to match column keys.
+- For multi-select columns, return arrays or JSON strings of arrays.
+- For numeric/date range filters, return a JSON object (example: `{ "mode": ">=", "min": 100000 }`) so the UI can parse it into header filter state.
 
-These response filters will be applied by the client and kept in sync as the user adjusts column filters in the grid header.【F:DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx†L52-L169】
+These response filters are applied to the grid and stay synchronized as users refine column header filters.【F:DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx†L52-L169】


### PR DESCRIPTION
### Motivation
- Clarify the exact call flow used by the SVT List control so integrators understand how the unbound custom API is invoked and executed.
- Explain how request parameters (filters, paging, sorting, prefilters, and `columnFilters`) are built, normalized, and stringified before being sent.
- Document the accepted response shapes and the client-side normalization into `TaskSearchResponse` so API implementers can return compatible payloads.
- Address inline feedback to explain the involved methods in a clear, step-by-step manner.

### Description
- Rewrote `docs/svtGetSaleRecords.md` to add a detailed method flow showing `GridDataController.loadGridData` → `execCustomApi` → `CustomApi.executeUnboundCustomApi` → `buildUnboundCustomApiRequest` → `Xrm.WebApi.execute`.
- Added explicit guidance that all API parameters are sent as string values and described how pagination, sorting, top-of-grid filters, prefilters, and `columnFilters` are constructed and serialized.
- Documented the two accepted response shapes (`TaskSearchResponse` and `SalesApiResponse`), the one-to-one item field mapping to `TaskSearchItem`, and how `pageInfo` maps to grid paging fields.
- Described how returned `filters` are normalized by `normalizeApiFilters` to seed or sync column header filter state and provided practical response guidance for APIs.

### Testing
- No automated tests were run because this is a documentation-only change.
- The only modified file is `docs/svtGetSaleRecords.md` and the change is purely explanatory with no runtime code updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff40ad334832cb6d8feaf5d7c3dca)