### PR TITLE
Add custom API models and query helper for SVT sales records

### DIFF
--- a/VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/APIRequestConfiguration.cs
+++ b/VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/APIRequestConfiguration.cs
@@ -1,0 +1,12 @@
+namespace VOA.SVT.Plugins.CustomAPI.DataAccessLayer.Model
+{
+    public sealed class APIRequestConfiguration
+    {
+        public string Address { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string Scope { get; set; }
+        public string APIMSubscriptionKey { get; set; }
+        public string TenantId { get; set; }
+    }
+}

--- a/VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/AuthResult.cs
+++ b/VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/AuthResult.cs
@@ -1,0 +1,9 @@
+namespace VOA.SVT.Plugins.CustomAPI.DataAccessLayer.Model
+{
+    public sealed class AuthResult
+    {
+        public string AccessToken { get; set; }
+        public string TokenType { get; set; }
+        public int ExpiresIn { get; set; }
+    }
+}

--- a/VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/SalesRecordModels.cs
+++ b/VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/SalesRecordModels.cs
@@ -1,0 +1,135 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace VOA.SVT.Plugins.CustomAPI.DataAccessLayer.Model
+{
+    public sealed class SalesRecordSearchRequest
+    {
+        public string PageNumber { get; set; }
+        public string PageSize { get; set; }
+        public string Source { get; set; }
+        public string SaleId { get; set; }
+        public string TaskId { get; set; }
+        public string UPRN { get; set; }
+        public string Address { get; set; }
+        public string BuildingNameOrNumber { get; set; }
+        public string Street { get; set; }
+        public string Town { get; set; }
+        public string Postcode { get; set; }
+        public string BillingAuthority { get; set; }
+        public string BillingAuthorityReference { get; set; }
+        public string TransactionDate { get; set; }
+        public string SalesPrice { get; set; }
+        public string SalesPriceOperator { get; set; }
+        public string Ratio { get; set; }
+        public string DwellingType { get; set; }
+        public string FlaggedForReview { get; set; }
+        public string ReviewFlag { get; set; }
+        public string OutlierKeySale { get; set; }
+        public string OutlierRatio { get; set; }
+        public string OverallFlag { get; set; }
+        public string SummaryFlag { get; set; }
+        public string TaskStatus { get; set; }
+        public string AssignedTo { get; set; }
+        public string AssignedFromDate { get; set; }
+        public string AssignedToDate { get; set; }
+        public string QcAssignedTo { get; set; }
+        public string QcAssignedFromDate { get; set; }
+        public string QcAssignedToDate { get; set; }
+        public string QcCompleteFromDate { get; set; }
+        public string QcCompleteToDate { get; set; }
+
+        public IDictionary<string, string> ToQueryParameters()
+        {
+            var parameters = new Dictionary<string, string>
+            {
+                ["pageNumber"] = PageNumber,
+                ["pageSize"] = PageSize,
+                ["source"] = Source,
+                ["saleId"] = SaleId,
+                ["taskId"] = TaskId,
+                ["uprn"] = UPRN,
+                ["address"] = Address,
+                ["buildingNameOrNumber"] = BuildingNameOrNumber,
+                ["street"] = Street,
+                ["town"] = Town,
+                ["postcode"] = Postcode,
+                ["billingAuthority"] = BillingAuthority,
+                ["billingAuthorityReference"] = BillingAuthorityReference,
+                ["transactionDate"] = TransactionDate,
+                ["salesPrice"] = SalesPrice,
+                ["salesPriceOperator"] = SalesPriceOperator,
+                ["ratio"] = Ratio,
+                ["dwellingType"] = DwellingType,
+                ["flaggedForReview"] = FlaggedForReview,
+                ["reviewFlag"] = ReviewFlag,
+                ["outlierKeySale"] = OutlierKeySale,
+                ["outlierRatio"] = OutlierRatio,
+                ["overallFlag"] = OverallFlag,
+                ["summaryFlag"] = SummaryFlag,
+                ["taskStatus"] = TaskStatus,
+                ["assignedTo"] = AssignedTo,
+                ["assignedFromDate"] = AssignedFromDate,
+                ["assignedToDate"] = AssignedToDate,
+                ["qcAssignedTo"] = QcAssignedTo,
+                ["qcAssignedFromDate"] = QcAssignedFromDate,
+                ["qcAssignedToDate"] = QcAssignedToDate,
+                ["qcCompleteFromDate"] = QcCompleteFromDate,
+                ["qcCompleteToDate"] = QcCompleteToDate,
+            };
+
+            return parameters
+                .Where(pair => !string.IsNullOrWhiteSpace(pair.Value))
+                .ToDictionary(pair => pair.Key, pair => pair.Value);
+        }
+
+        public string ToQueryString()
+        {
+            var parameters = ToQueryParameters();
+            return string.Join("&", parameters.Select(pair =>
+                $"{pair.Key}={HttpUtility.UrlEncode(pair.Value)}"));
+        }
+    }
+
+    public sealed class SalesRecordPageInfo
+    {
+        public int? PageNumber { get; set; }
+        public int? PageSize { get; set; }
+        public int? TotalRecords { get; set; }
+    }
+
+    public sealed class SalesRecordItem
+    {
+        public string SaleId { get; set; }
+        public string TaskId { get; set; }
+        public string UPRN { get; set; }
+        public string Address { get; set; }
+        public string Postcode { get; set; }
+        public string BillingAuthority { get; set; }
+        public string TransactionDate { get; set; }
+        public decimal? SalesPrice { get; set; }
+        public decimal? Ratio { get; set; }
+        public string DwellingType { get; set; }
+        public bool? FlaggedForReview { get; set; }
+        public string[] ReviewFlags { get; set; }
+        public decimal? OutlierRatio { get; set; }
+        public string OverallFlag { get; set; }
+        public string[] SummaryFlags { get; set; }
+        public string TaskStatus { get; set; }
+        public string[] AssignedTo { get; set; }
+        public string AssignedDate { get; set; }
+        public string TaskCompletedDate { get; set; }
+        public string[] QcAssignedTo { get; set; }
+        public string QcAssignedDate { get; set; }
+        public string QcCompletedDate { get; set; }
+        public string Source { get; set; }
+    }
+
+    public sealed class SalesRecordResponse
+    {
+        public SalesRecordPageInfo PageInfo { get; set; }
+        public IList<SalesRecordItem> Sales { get; set; }
+        public IDictionary<string, object> Filters { get; set; }
+    }
+}

--- a/VOA.SVT.Plugins/Plugins/CustomAPI/GetAllSalesRecord.cs
+++ b/VOA.SVT.Plugins/Plugins/CustomAPI/GetAllSalesRecord.cs
@@ -1,0 +1,163 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Extensions;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web;
+using VOA.Common;
+using VOA.SVT.Plugins.CustomAPI.DataAccessLayer.Model;
+using VOA.SVT.Plugins.CustomAPI.Helpers;
+using VOA.SVT.Plugins.Helpers;
+
+namespace VOA.SVT.Plugins.CustomAPI
+{
+    public class GetAllSalesRecord : PluginBase
+    {
+        /// <summary>
+        /// Name of the API configuration returned by voa_CredentialProvider
+        /// </summary>
+        private const string CONFIGURATION_NAME = "SVTGetSalesRecord";
+
+        public GetAllSalesRecord(string unsecureConfiguration, string secureConfiguration)
+            : base(typeof(GetAllSalesRecord))
+        {
+            // Custom API plugin -> generally no secure/unsecure config usage.
+        }
+
+        protected override void ExecuteCdsPlugin(ILocalPluginContext localPluginContext)
+        {
+            if (localPluginContext == null)
+            {
+                throw new ArgumentNullException(nameof(localPluginContext));
+            }
+
+            var context = localPluginContext.PluginExecutionContext;
+
+            // 1) Read secrets/config from credential provider action
+            var getSecretsRequest = new OrganizationRequest("voa_CredentialProvider")
+            {
+                ["ConfigurationName"] = CONFIGURATION_NAME
+            };
+
+            localPluginContext.TracingService.Trace("Retrieving configuration from voa_CredentialProvider...");
+
+            var getSecretsResponse = localPluginContext.SystemUserService.Execute(getSecretsRequest);
+
+            var apiConfig = new APIRequestConfiguration
+            {
+                Address = getSecretsResponse.Results.Contains("Address") ? (string)getSecretsResponse.Results["Address"] : null,
+                ClientId = getSecretsResponse.Results.Contains("ClientId") ? (string)getSecretsResponse.Results["ClientId"] : null,
+                ClientSecret = getSecretsResponse.Results.Contains("ClientSecret") ? (string)getSecretsResponse.Results["ClientSecret"] : null,
+                Scope = getSecretsResponse.Results.Contains("Scope") ? (string)getSecretsResponse.Results["Scope"] : null,
+                APIMSubscriptionKey = getSecretsResponse.Results.Contains("APIMSubscriptionKey") ? (string)getSecretsResponse.Results["APIMSubscriptionKey"] : null,
+                TenantId = getSecretsResponse.Results.Contains("TenantId") ? (string)getSecretsResponse.Results["TenantId"] : null
+            };
+
+            if (string.IsNullOrWhiteSpace(apiConfig.Address))
+            {
+                throw new InvalidPluginExecutionException("SVTGetSalesRecord configuration missing Address.");
+            }
+
+            localPluginContext.TracingService.Trace("SVT GetAllSalesRecord started.");
+
+            // 2) OAuth token (if needed)
+            localPluginContext.TracingService.Trace("Generating authentication token...");
+            var auth = new Authentication(localPluginContext, apiConfig);
+            var authResult = auth.GenerateAuthentication();
+
+            // 3) Build full URL (base Address + query from Custom API inputs)
+            var searchQuery = CustomApiQueryHelper.BuildSearchQuery(context.InputParameters);
+            var fullUrl = BuildUrl(apiConfig.Address, searchQuery);
+
+            localPluginContext.TracingService.Trace($"Calling APIM URL: {Truncate(fullUrl, 300)}");
+
+            using (var httpClient = new HttpClient())
+            {
+                httpClient.Timeout = TimeSpan.FromSeconds(30);
+
+                // Optional: add correlation headers etc (your helper)
+                httpClient.ApplyVOAConfiguration(localPluginContext);
+
+                // APIM subscription key
+                if (!string.IsNullOrWhiteSpace(apiConfig.APIMSubscriptionKey))
+                {
+                    httpClient.DefaultRequestHeaders.Remove("Ocp-Apim-Subscription-Key");
+                    httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", apiConfig.APIMSubscriptionKey);
+                }
+
+                // Bearer token (only if APIM requires it)
+                if (!string.IsNullOrWhiteSpace(authResult?.AccessToken))
+                {
+                    httpClient.DefaultRequestHeaders.Authorization =
+                        new AuthenticationHeaderValue("Bearer", authResult.AccessToken);
+                }
+
+                using (var request = new HttpRequestMessage(HttpMethod.Get, fullUrl))
+                {
+                    HttpResponseMessage response = null;
+                    string body = string.Empty;
+
+                    try
+                    {
+                        // Sync plugin: avoid deadlocks by using GetAwaiter().GetResult()
+                        response = httpClient.SendAsync(request).GetAwaiter().GetResult();
+                        body = response.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;
+
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            localPluginContext.TracingService.Trace(
+                                $"APIM call failed. Status={(int)response.StatusCode} {response.ReasonPhrase}. BodySnippet={Truncate(body, 500)}");
+
+                            throw new InvalidPluginExecutionException(
+                                $"APIM call failed ({(int)response.StatusCode} {response.ReasonPhrase}). " +
+                                $"URL: {Truncate(fullUrl, 300)}. Body: {Truncate(body, 1000)}");
+                        }
+
+                        // Trace minimal response snippet (avoid PII / noisy logs)
+                        localPluginContext.TracingService.Trace($"APIM response snippet: {Truncate(body, 200)}");
+
+                        // Return raw JSON back via Custom API output parameter (Result)
+                        context.OutputParameters["Result"] = body;
+                        localPluginContext.TracingService.Trace("SVT GetAllSalesRecord completed successfully.");
+                    }
+                    catch (Exception ex)
+                    {
+                        localPluginContext.TracingService.Trace($"APIM call exception: {ex}");
+                        throw new InvalidPluginExecutionException(
+                            "Failed to call APIM for SVT sales records. See trace for details.", ex);
+                    }
+                    finally
+                    {
+                        response?.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static string BuildUrl(string baseAddress, string searchQuery)
+        {
+            if (string.IsNullOrWhiteSpace(searchQuery))
+            {
+                return baseAddress;
+            }
+
+            var trimmed = searchQuery.Trim();
+            if (trimmed.StartsWith("?", StringComparison.Ordinal))
+            {
+                trimmed = trimmed.Substring(1);
+            }
+
+            if (baseAddress.Contains("?"))
+            {
+                return baseAddress.EndsWith("&", StringComparison.Ordinal)
+                    ? baseAddress + HttpUtility.UrlEncode(trimmed)
+                    : baseAddress + "&" + trimmed;
+            }
+
+            return baseAddress + "?" + trimmed;
+        }
+
+        private static string Truncate(string s, int maxLen)
+            => string.IsNullOrEmpty(s) ? s : (s.Length > maxLen ? s.Substring(0, maxLen) : s);
+    }
+}

--- a/VOA.SVT.Plugins/Plugins/CustomAPI/Helpers/CustomApiQueryHelper.cs
+++ b/VOA.SVT.Plugins/Plugins/CustomAPI/Helpers/CustomApiQueryHelper.cs
@@ -1,0 +1,91 @@
+using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using VOA.SVT.Plugins.CustomAPI.DataAccessLayer.Model;
+
+namespace VOA.SVT.Plugins.CustomAPI.Helpers
+{
+    public static class CustomApiQueryHelper
+    {
+        public static string BuildSearchQuery(ParameterCollection inputParameters)
+        {
+            var explicitQuery = GetString(inputParameters, "SearchQuery");
+            var request = BuildRequestFromInputs(inputParameters);
+            var queryFromInputs = request.ToQueryString();
+
+            if (string.IsNullOrWhiteSpace(explicitQuery))
+            {
+                return queryFromInputs;
+            }
+
+            var normalizedExplicit = NormalizeQueryString(explicitQuery);
+            if (string.IsNullOrWhiteSpace(queryFromInputs))
+            {
+                return normalizedExplicit;
+            }
+
+            return $"{queryFromInputs}&{normalizedExplicit}";
+        }
+
+        public static SalesRecordSearchRequest BuildRequestFromInputs(ParameterCollection inputParameters)
+        {
+            return new SalesRecordSearchRequest
+            {
+                PageNumber = GetString(inputParameters, "pageNumber"),
+                PageSize = GetString(inputParameters, "pageSize"),
+                Source = GetString(inputParameters, "source"),
+                SaleId = GetString(inputParameters, "saleId"),
+                TaskId = GetString(inputParameters, "taskId"),
+                UPRN = GetString(inputParameters, "uprn"),
+                Address = GetString(inputParameters, "address"),
+                BuildingNameOrNumber = GetString(inputParameters, "buildingNameOrNumber"),
+                Street = GetString(inputParameters, "street"),
+                Town = GetString(inputParameters, "town"),
+                Postcode = GetString(inputParameters, "postcode"),
+                BillingAuthority = GetString(inputParameters, "billingAuthority"),
+                BillingAuthorityReference = GetString(inputParameters, "billingAuthorityReference"),
+                TransactionDate = GetString(inputParameters, "transactionDate"),
+                SalesPrice = GetString(inputParameters, "salesPrice"),
+                SalesPriceOperator = GetString(inputParameters, "salesPriceOperator"),
+                Ratio = GetString(inputParameters, "ratio"),
+                DwellingType = GetString(inputParameters, "dwellingType"),
+                FlaggedForReview = GetString(inputParameters, "flaggedForReview"),
+                ReviewFlag = GetString(inputParameters, "reviewFlag"),
+                OutlierKeySale = GetString(inputParameters, "outlierKeySale"),
+                OutlierRatio = GetString(inputParameters, "outlierRatio"),
+                OverallFlag = GetString(inputParameters, "overallFlag"),
+                SummaryFlag = GetString(inputParameters, "summaryFlag"),
+                TaskStatus = GetString(inputParameters, "taskStatus"),
+                AssignedTo = GetString(inputParameters, "assignedTo"),
+                AssignedFromDate = GetString(inputParameters, "assignedFromDate"),
+                AssignedToDate = GetString(inputParameters, "assignedToDate"),
+                QcAssignedTo = GetString(inputParameters, "qcAssignedTo"),
+                QcAssignedFromDate = GetString(inputParameters, "qcAssignedFromDate"),
+                QcAssignedToDate = GetString(inputParameters, "qcAssignedToDate"),
+                QcCompleteFromDate = GetString(inputParameters, "qcCompleteFromDate"),
+                QcCompleteToDate = GetString(inputParameters, "qcCompleteToDate"),
+            };
+        }
+
+        private static string NormalizeQueryString(string query)
+        {
+            var trimmed = query?.Trim() ?? string.Empty;
+            if (trimmed.StartsWith("?", StringComparison.Ordinal))
+            {
+                return trimmed.Substring(1);
+            }
+            return trimmed;
+        }
+
+        private static string GetString(ParameterCollection inputParameters, string key)
+        {
+            if (inputParameters == null || !inputParameters.Contains(key))
+            {
+                return null;
+            }
+
+            var value = inputParameters[key];
+            return value == null ? null : value.ToString();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide concrete request/response models and auth/config types so the Custom API plugin can produce the exact query and consume APIM JSON for sales records.
- Align PCF control inputs to the Custom API parameters so the PCF can call the plugin using the same names and semantics used by APIM.
- Encapsulate query-building logic so the plugin can merge an explicit `SearchQuery` string with named input parameters reliably.

### Description
- Add `APIRequestConfiguration` and `AuthResult` types at `VOA.SVT.Plugins/Plugins/CustomAPI/DataAccessLayer/Model/` to hold APIM/ OAuth configuration and token results.
- Add `SalesRecordSearchRequest`, `SalesRecordItem`, `SalesRecordResponse`, and `SalesRecordPageInfo` in `SalesRecordModels.cs` with `ToQueryParameters()` and `ToQueryString()` to map PCF inputs to APIM query parameters.
- Add `CustomApiQueryHelper` at `VOA.SVT.Plugins/Plugins/CustomAPI/Helpers/CustomApiQueryHelper.cs` which builds a merged query string from `ParameterCollection` inputs and the optional `SearchQuery` parameter.
- Add `GetAllSalesRecord` plugin at `VOA.SVT.Plugins/Plugins/CustomAPI/GetAllSalesRecord.cs` wired to use the new models and `CustomApiQueryHelper` to construct the APIM URL and perform the HTTP request.

### Testing
- No automated tests were executed as part of this change.
- The changes are limited to new types and a plugin wiring helper and should be safe to compile into the plugin project before runtime testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696043f4b4cc832cbd4cdb0fef5313da)