### PR TITLE
Custom API: allow manifest-configurable name and set operationType to action (1)

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -19,6 +19,15 @@
     <!-- Removed dataset-bound task properties for unbound API-first control -->
 
     <property name="canvasScreenName" display-name-key="Canvas Screen Name" description-key="Name of the Canvas App screen to navigate to on row click (e.g., svt-sale-details)." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
+    <property
+      name="customApiName"
+      display-name-key="Custom API Name"
+      description-key="Name of the Dataverse Custom API used for search (e.g., voa_GetAllSalesRecord)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value="voa_GetAllSalesRecord"
+    />
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
     <!-- Optional mapping of column logical names to display names as JSON -->

--- a/DetailsListVOA/config/ControlConfig.ts
+++ b/DetailsListVOA/config/ControlConfig.ts
@@ -1,5 +1,5 @@
 export const CONTROL_CONFIG = {
   apiBaseUrl: '',
-  customApiName: 'svtGetSaleRecords',
+  customApiName: 'voa_GetAllSalesRecord',
   tableKey: 'sales',
 };

--- a/DetailsListVOA/generated/ManifestTypes.ts
+++ b/DetailsListVOA/generated/ManifestTypes.ts
@@ -1,5 +1,6 @@
 export interface IInputs {
     canvasScreenName: ComponentFramework.PropertyTypes.StringProperty;
+    customApiName: ComponentFramework.PropertyTypes.StringProperty;
     pageSize: ComponentFramework.PropertyTypes.WholeNumberProperty;
     columnDisplayNames: ComponentFramework.PropertyTypes.StringProperty;
     columnConfig: ComponentFramework.PropertyTypes.StringProperty;

--- a/DetailsListVOA/services/CustomApi.ts
+++ b/DetailsListVOA/services/CustomApi.ts
@@ -49,7 +49,7 @@ export const buildUnboundCustomApiRequest = (
         acc[key] = { typeName: 'Edm.String', structuralProperty: 1 };
         return acc;
       }, {} as Record<string, { typeName: string; structuralProperty: number }>),
-      operationType: 0,
+      operationType: 1,
       operationName,
     }),
   };

--- a/DetailsListVOA/services/DataService.ts
+++ b/DetailsListVOA/services/DataService.ts
@@ -181,6 +181,12 @@ const unwrapCustomApiPayload = (payload: unknown): SalesPayload => {
   return payload as SalesPayload;
 };
 
+const resolveCustomApiName = (context: ComponentFramework.Context<IInputs>): string => {
+  const raw = (context.parameters as unknown as Record<string, { raw?: string }>).customApiName?.raw;
+  const fromContext = typeof raw === 'string' ? raw.trim() : '';
+  return fromContext || CONTROL_CONFIG.customApiName?.trim() || '';
+};
+
 export async function executeSearch(
   context: ComponentFramework.Context<IInputs>,
   req: SearchRequest,
@@ -189,7 +195,7 @@ export async function executeSearch(
 
   const apiParams = buildApiParamsFor(tableKey, filters, page, pageSize);
 
-  const customApiName = CONTROL_CONFIG.customApiName?.trim() ?? '';
+  const customApiName = resolveCustomApiName(context);
   if (!customApiName) {
     return {
       items: SAMPLE_TASK_RESULTS,
@@ -229,7 +235,7 @@ export async function fetchFilterOptions(
   req: FilterOptionsRequest,
 ): Promise<string[]> {
   const { tableKey, field, query } = req;
-  const customApiName = CONTROL_CONFIG.customApiName?.trim() ?? '';
+  const customApiName = resolveCustomApiName(context);
   if (!customApiName) return [];
   // Unbound Custom API variant for filter suggestions
   const actionName = `${customApiName}_FilterOptions`;

--- a/DetailsListVOA/services/GridDataController.ts
+++ b/DetailsListVOA/services/GridDataController.ts
@@ -53,6 +53,12 @@ const getPrefilterParams = (context: ComponentFramework.Context<IInputs>): Recor
   return result;
 };
 
+const resolveCustomApiName = (context: ComponentFramework.Context<IInputs>): string => {
+  const raw = (context.parameters as unknown as Record<string, { raw?: string }>).customApiName?.raw;
+  const fromContext = typeof raw === 'string' ? raw.trim() : '';
+  return fromContext || CONTROL_CONFIG.customApiName?.trim() || '';
+};
+
 export async function loadGridData(
   context: ComponentFramework.Context<IInputs>,
   args: {
@@ -71,7 +77,7 @@ export async function loadGridData(
     Array.isArray(v) ? v.length > 0 : (v ?? '').toString().trim() !== '',
   );
 
-  const customApiName = CONTROL_CONFIG.customApiName?.trim() ?? '';
+  const customApiName = resolveCustomApiName(context);
 
   const sortBy = args.clientSort?.name;
   const sortDirection = args.clientSort?.sortDirection;


### PR DESCRIPTION
### Motivation
- Allow the Dataverse Custom API that the PCF control calls to be overridden from the control manifest while defaulting to `voa_GetAllSalesRecord`.
- Ensure unbound Custom API requests are executed as actions by setting the metadata `operationType` to `1`.
- Preserve an in-code fallback value in `CONTROL_CONFIG` when no manifest input is provided.

### Description
- Added a `customApiName` input property to `DetailsListVOA/ControlManifest.Input.xml` with default `voa_GetAllSalesRecord` and exposed it in `DetailsListVOA/generated/ManifestTypes.ts`.
- Updated `DetailsListVOA/config/ControlConfig.ts` to change the default `customApiName` to `voa_GetAllSalesRecord`.
- Implemented `resolveCustomApiName(context)` in `DetailsListVOA/services/DataService.ts` and `DetailsListVOA/services/GridDataController.ts` and replaced direct `CONTROL_CONFIG.customApiName` usage with the resolver so manifest values take precedence.
- Set `operationType` to `1` in `DetailsListVOA/services/CustomApi.ts` when building unbound Custom API requests so the Web API executes the call as an action.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614bd2f5e0832cbdd4e06b1431abb4)