### PR TITLE
Support function/action custom API execution

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -28,6 +28,15 @@
       required="false"
       default-value="voa_GetAllSalesRecord"
     />
+    <property
+      name="customApiType"
+      display-name-key="Custom API Type"
+      description-key="Custom API operation type: function (GET) or action (POST)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value="function"
+    />
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
     <!-- Optional mapping of column logical names to display names as JSON -->

--- a/DetailsListVOA/config/ControlConfig.ts
+++ b/DetailsListVOA/config/ControlConfig.ts
@@ -1,5 +1,6 @@
 export const CONTROL_CONFIG = {
   apiBaseUrl: '',
   customApiName: 'voa_GetAllSalesRecord',
+  customApiType: 'function',
   tableKey: 'sales',
 };

--- a/DetailsListVOA/generated/ManifestTypes.ts
+++ b/DetailsListVOA/generated/ManifestTypes.ts
@@ -1,6 +1,7 @@
 export interface IInputs {
     canvasScreenName: ComponentFramework.PropertyTypes.StringProperty;
     customApiName: ComponentFramework.PropertyTypes.StringProperty;
+    customApiType: ComponentFramework.PropertyTypes.StringProperty;
     pageSize: ComponentFramework.PropertyTypes.WholeNumberProperty;
     columnDisplayNames: ComponentFramework.PropertyTypes.StringProperty;
     columnConfig: ComponentFramework.PropertyTypes.StringProperty;


### PR DESCRIPTION
### Motivation
- Dataverse custom APIs can be registered as functions (GET) or actions (POST), and the Web API `execute` metadata must contain the correct `operationType` for the request to succeed. 
- Consumers need an easy way to configure whether a custom API should be invoked as a function or an action. 
- Existing name normalization is helpful but insufficient when the wrong operation type is sent to the Web API. 

### Description
- Add a new control property `customApiType` to `ControlManifest.Input.xml` and a default `customApiType` in `CONTROL_CONFIG` to choose between `function` and `action`. 
- Introduce `CustomApiOperationType` and `resolveCustomApiOperationType` in `DetailsListVOA/services/CustomApi.ts`, extend `buildUnboundCustomApiRequest` to accept `operationType`, and allow `executeUnboundCustomApi` to receive an `{ operationType?: number }` option. 
- Update `DetailsListVOA/services/DataService.ts` and `DetailsListVOA/services/GridDataController.ts` to read `customApiType` from the manifest/context and pass the resolved `operationType` into `executeUnboundCustomApi`. 
- Update generated manifest typings (`generated/ManifestTypes.ts`) to include `customApiType`. 

### Testing
- No automated tests were executed for this change. 
- Changes are limited to request metadata and manifest/config wiring and require runtime `webAPI`/`Xrm.WebApi` to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696163043188832cb31ccf0e3d5cbbe6)