### PR TITLE
Fix server-driven pagination slicing

### DIFF
--- a/DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx
+++ b/DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx
@@ -431,12 +431,16 @@ export const DetailsListHost: React.FC<DetailsListHostProps> = ({ context, onRow
   }, [clientSort, filteredIds, records, serverDriven]);
 
   const start = currentPage * pageSize;
-  const pageSliceT0 = performance.now();
-  const pageIds = sortedIds.slice(start, start + pageSize);
-  const pageSliceT1 = performance.now();
-  if (sortedIds.length > 0) {
-    logPerf('[Grid Perf] Host page slice (ms):', Math.round(pageSliceT1 - pageSliceT0), 'start:', start, 'size:', pageSize, 'result:', pageIds.length);
-  }
+  const pageIds = React.useMemo(() => {
+    if (serverDriven) return filteredIds;
+    const pageSliceT0 = performance.now();
+    const slice = sortedIds.slice(start, start + pageSize);
+    const pageSliceT1 = performance.now();
+    if (sortedIds.length > 0) {
+      logPerf('[Grid Perf] Host page slice (ms):', Math.round(pageSliceT1 - pageSliceT0), 'start:', start, 'size:', pageSize, 'result:', slice.length);
+    }
+    return slice;
+  }, [filteredIds, serverDriven, sortedIds, start, pageSize]);
   const canPrev = currentPage > 0;
   const canNext = serverDriven ? (currentPage + 1) * pageSize < totalCount : start + pageSize < filteredIds.length;
   const totalPages = serverDriven ? Math.ceil(totalCount / pageSize) : Math.ceil(filteredIds.length / pageSize);


### PR DESCRIPTION
### Motivation
- The host was slicing `sortedIds` on every page even when the grid is server-driven, causing pages beyond the server threshold to show incorrect items.
- When `serverDriven` is true the intent is to use the API-provided page rather than re-slicing client-side results. 
- Improve perf by memoizing client-side slicing so repeated renders don't re-compute the slice unnecessarily. 

### Description
- Replace the previous direct slice with a `React.useMemo` that returns `filteredIds` when `serverDriven` is true and otherwise computes `sortedIds.slice(start, start + pageSize)`.
- Keep existing performance logging around page slicing and move it into the memoized function. 
- Add appropriate memo dependencies (`filteredIds`, `serverDriven`, `sortedIds`, `start`, `pageSize`) to ensure correct recomputation. 

### Testing
- No automated tests were run for this change.
- (CI/unit tests were not executed as part of this rollout.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69626f5da278832c989968f05098037e)