### PR TITLE
Add GetViewSaleRecordById custom API and PCF integration

### DIFF
--- a/DetailsListVOA/ControlManifest.Input.xml
+++ b/DetailsListVOA/ControlManifest.Input.xml
@@ -37,6 +37,15 @@
       required="false"
       default-value="function"
     />
+    <property
+      name="viewSaleRecordApiName"
+      display-name-key="View Sale Record API Name"
+      description-key="Name of the Dataverse Custom API used to fetch sale details by ID (e.g., voa_GetViewSaleRecordById)."
+      of-type="SingleLine.Text"
+      usage="input"
+      required="false"
+      default-value="voa_GetViewSaleRecordById"
+    />
     <!-- Number of records shown per page -->
     <property name="pageSize" display-name-key="PageSize" description-key="PageSize description" of-type="Whole.None" usage="input" required="false" default-value="10" />
     <property

--- a/DetailsListVOA/config/ControlConfig.ts
+++ b/DetailsListVOA/config/ControlConfig.ts
@@ -2,6 +2,7 @@ export const CONTROL_CONFIG = {
   apiBaseUrl: '',
   customApiName: 'voa_GetAllSalesRecord',
   customApiType: 'function',
+  viewSaleRecordApiName: 'voa_GetViewSaleRecordById',
   tableKey: 'sales',
   serverDrivenThreshold: 2000,
 };

--- a/DetailsListVOA/generated/ManifestTypes.ts
+++ b/DetailsListVOA/generated/ManifestTypes.ts
@@ -2,6 +2,7 @@ export interface IInputs {
     canvasScreenName: ComponentFramework.PropertyTypes.StringProperty;
     customApiName: ComponentFramework.PropertyTypes.StringProperty;
     customApiType: ComponentFramework.PropertyTypes.StringProperty;
+    viewSaleRecordApiName: ComponentFramework.PropertyTypes.StringProperty;
     pageSize: ComponentFramework.PropertyTypes.WholeNumberProperty;
     columnDisplayNames: ComponentFramework.PropertyTypes.StringProperty;
     columnConfig: ComponentFramework.PropertyTypes.StringProperty;

--- a/VOA.SVT.Plugins/Plugins/CustomAPI/GetViewSaleRecordById.cs
+++ b/VOA.SVT.Plugins/Plugins/CustomAPI/GetViewSaleRecordById.cs
@@ -1,0 +1,172 @@
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Extensions;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using VOA.Common;
+using VOA.SVT.Plugins.CustomAPI.DataAccessLayer.Model;
+using VOA.SVT.Plugins.Helpers;
+
+namespace VOA.SVT.Plugins.CustomAPI
+{
+    public class GetViewSaleRecordById : PluginBase
+    {
+        /// <summary>
+        /// Name of the API configuration returned by voa_CredentialProvider
+        /// </summary>
+        private const string CONFIGURATION_NAME = "SVTGetViewSaleRecordById";
+
+        public GetViewSaleRecordById(string unsecureConfiguration, string secureConfiguration)
+            : base(typeof(GetViewSaleRecordById))
+        {
+            // Custom API plugin -> generally no secure/unsecure config usage.
+        }
+
+        protected override void ExecuteCdsPlugin(ILocalPluginContext localPluginContext)
+        {
+            if (localPluginContext == null)
+            {
+                throw new ArgumentNullException(nameof(localPluginContext));
+            }
+
+            var context = localPluginContext.PluginExecutionContext;
+            var saleId = context.InputParameters.Contains("saleId")
+                ? context.InputParameters["saleId"]?.ToString()
+                : null;
+
+            if (string.IsNullOrWhiteSpace(saleId))
+            {
+                throw new InvalidPluginExecutionException("saleId is required.");
+            }
+
+            // 1) Read secrets/config from credential provider action
+            var getSecretsRequest = new OrganizationRequest("voa_CredentialProvider")
+            {
+                ["ConfigurationName"] = CONFIGURATION_NAME
+            };
+
+            localPluginContext.TracingService.Trace("Retrieving configuration from voa_CredentialProvider...");
+
+            var getSecretsResponse = localPluginContext.SystemUserService.Execute(getSecretsRequest);
+
+            var apiConfig = new APIRequestConfiguration
+            {
+                Address = getSecretsResponse.Results.Contains("Address") ? (string)getSecretsResponse.Results["Address"] : null,
+                ClientId = getSecretsResponse.Results.Contains("ClientId") ? (string)getSecretsResponse.Results["ClientId"] : null,
+                ClientSecret = getSecretsResponse.Results.Contains("ClientSecret") ? (string)getSecretsResponse.Results["ClientSecret"] : null,
+                Scope = getSecretsResponse.Results.Contains("Scope") ? (string)getSecretsResponse.Results["Scope"] : null,
+                APIMSubscriptionKey = getSecretsResponse.Results.Contains("APIMSubscriptionKey") ? (string)getSecretsResponse.Results["APIMSubscriptionKey"] : null,
+                TenantId = getSecretsResponse.Results.Contains("TenantId") ? (string)getSecretsResponse.Results["TenantId"] : null
+            };
+
+            if (string.IsNullOrWhiteSpace(apiConfig.Address))
+            {
+                throw new InvalidPluginExecutionException("SVTGetViewSaleRecordById configuration missing Address.");
+            }
+
+            localPluginContext.TracingService.Trace("SVT GetViewSaleRecordById started.");
+
+            // 2) OAuth token (if needed)
+            localPluginContext.TracingService.Trace("Generating authentication token...");
+            var auth = new Authentication(localPluginContext, apiConfig);
+            var authResult = auth.GenerateAuthentication();
+
+            // 3) Build full URL (base Address + path from Custom API inputs)
+            var fullUrl = BuildUrl(apiConfig.Address, saleId);
+
+            localPluginContext.TracingService.Trace($"Calling APIM URL: {Truncate(fullUrl, 300)}");
+
+            using (var httpClient = new HttpClient())
+            {
+                httpClient.Timeout = TimeSpan.FromSeconds(30);
+
+                // Optional: add correlation headers etc (your helper)
+                httpClient.ApplyVOAConfiguration(localPluginContext);
+
+                // APIM subscription key
+                if (!string.IsNullOrWhiteSpace(apiConfig.APIMSubscriptionKey))
+                {
+                    httpClient.DefaultRequestHeaders.Remove("Ocp-Apim-Subscription-Key");
+                    httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", apiConfig.APIMSubscriptionKey);
+                }
+
+                // Bearer token (only if APIM requires it)
+                if (!string.IsNullOrWhiteSpace(authResult?.AccessToken))
+                {
+                    httpClient.DefaultRequestHeaders.Authorization =
+                        new AuthenticationHeaderValue("Bearer", authResult.AccessToken);
+                }
+
+                using (var request = new HttpRequestMessage(HttpMethod.Get, fullUrl))
+                {
+                    HttpResponseMessage response = null;
+                    string body = string.Empty;
+
+                    try
+                    {
+                        // Sync plugin: avoid deadlocks by using GetAwaiter().GetResult()
+                        response = httpClient.SendAsync(request).GetAwaiter().GetResult();
+                        body = response.Content?.ReadAsStringAsync().GetAwaiter().GetResult() ?? string.Empty;
+
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            localPluginContext.TracingService.Trace(
+                                $"APIM call failed. Status={(int)response.StatusCode} {response.ReasonPhrase}. BodySnippet={Truncate(body, 500)}");
+
+                            throw new InvalidPluginExecutionException(
+                                $"APIM call failed ({(int)response.StatusCode} {response.ReasonPhrase}). " +
+                                $"URL: {Truncate(fullUrl, 300)}. Body: {Truncate(body, 1000)}");
+                        }
+
+                        // Trace minimal response snippet (avoid PII / noisy logs)
+                        localPluginContext.TracingService.Trace($"APIM response snippet: {Truncate(body, 200)}");
+
+                        // Return raw JSON back via Custom API output parameter (Result)
+                        context.OutputParameters["Result"] = body;
+                        localPluginContext.TracingService.Trace("SVT GetViewSaleRecordById completed successfully.");
+                    }
+                    catch (Exception ex)
+                    {
+                        localPluginContext.TracingService.Trace($"APIM call exception: {ex}");
+                        throw new InvalidPluginExecutionException(
+                            "Failed to call APIM for SVT sale record. See trace for details.", ex);
+                    }
+                    finally
+                    {
+                        response?.Dispose();
+                    }
+                }
+            }
+        }
+
+        private static string BuildUrl(string baseAddress, string saleId)
+        {
+            if (string.IsNullOrWhiteSpace(baseAddress))
+            {
+                return baseAddress;
+            }
+
+            var trimmed = baseAddress.TrimEnd('/');
+
+            if (trimmed.Contains("{saleId}", StringComparison.Ordinal))
+            {
+                return trimmed.Replace("{saleId}", saleId);
+            }
+
+            if (trimmed.Contains("{id}", StringComparison.Ordinal))
+            {
+                return trimmed.Replace("{id}", saleId);
+            }
+
+            if (trimmed.EndsWith("/sales", StringComparison.OrdinalIgnoreCase))
+            {
+                return $"{trimmed}/{saleId}";
+            }
+
+            return $"{trimmed}/sales/{saleId}";
+        }
+
+        private static string Truncate(string s, int maxLen)
+            => string.IsNullOrEmpty(s) ? s : (s.Length > maxLen ? s.Substring(0, maxLen) : s);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a way to fetch a full sale record by ID when a user clicks a task in the PCF table.
- Make the view-sale-record API configurable from the control manifest so different environments can use different Dataverse custom API names.
- Ensure the PCF emits a canonical empty sale-details shape when no sale information is available or the call fails.

### Description
- Added a new Dataverse custom API plugin `GetViewSaleRecordById` that calls the upstream SVT APIM and returns the raw JSON in the `Result` output parameter (`VOA.SVT.Plugins/Plugins/CustomAPI/GetViewSaleRecordById.cs`).
- Wired a configurable API name `viewSaleRecordApiName` into the PCF manifest and control config (`DetailsListVOA/ControlManifest.Input.xml`, `DetailsListVOA/config/ControlConfig.ts`, `DetailsListVOA/generated/ManifestTypes.ts`).
- Updated the PCF host to call the unbound custom API via `executeUnboundCustomApi` when a task ID is clicked, to unwrap the `Result` if present, and to emit the response as the `saleDetails` output (`DetailsListVOA/index.ts`).
- Implemented a stable empty sale-record shape fallback returned as serialized JSON when the API is not configured or the call fails.

### Testing
- No automated tests were run for these changes.
- The change set was committed to the local branch successfully (no CI/test run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696278bcc3ac832c9f04c64878a94aaa)