### PR TITLE
docs: add SVT user context doc and expand manager/task assignment docs

### DIFF
--- a/docs/manager-assignment-technical-doc.md
+++ b/docs/manager-assignment-technical-doc.md
@@ -34,6 +34,17 @@ The prefilter model includes:
 
 These values are mapped into API parameters (e.g., `billingAuthority`, `assignedTo`, `taskStatus`, `completedFromDate`, `completedToDate`) before the Custom API call is made.【F:DetailsListVOA/config/PrefilterConfigs.ts†L9-L41】【F:DetailsListVOA/config/PrefilterConfigs.ts†L47-L90】
 
+## Assignment security context (roles + teams)
+### User context resolution
+SVT uses a **user context resolver** to determine persona (`Manager`, `QA`, or `User`) by checking **security-group teams first** and then **Dataverse roles** if no matching teams are found. The resolver looks for the configured team and role names (SVT Manager/QA/User) and returns the matched persona along with the resolution source and matched team/role names.【F:VOA.SVT.Plugins/Helpers/UserContextResolver.cs†L7-L200】
+
+The `voa_SvtGetUserContext` Custom API exposes this resolution result to Canvas apps, returning output parameters such as `svtPersona`, `hasSvtAccess`, `matchedTeamName`, `matchedRoleName`, and the semicolon-delimited `matchedRoleNames` list.【F:VOA.SVT.Plugins/Plugins/CustomAPI/SvtGetUserContext.cs†L8-L56】
+
+### Assignable users for manager assignment
+When the **assignment panel opens**, the PCF calls the **assignable users** Custom API (default `voa_SvtGetAssignableUsers`) with the current `screenName` to determine which users can be assigned. The request is cached per `assignmentContextKey` + API name/type, and the response is normalized into `{ id, firstName, lastName, email, team, role }` for the picker UI.【F:DetailsListVOA/components/DetailsListHost/DetailsListHost.tsx†L608-L707】【F:DetailsListVOA/config/ControlConfig.ts†L1-L12】
+
+The plugin resolves assignment context from the screen name (manager vs QA), then loads users from **team membership** and **role membership** using the assignment context’s configured team/role names (e.g., SVT User team or role for manager assignment).【F:VOA.SVT.Plugins/Plugins/CustomAPI/SvtGetAssignableUsers.cs†L24-L83】【F:VOA.SVT.Plugins/Helpers/AssignmentContextResolver.cs†L7-L95】
+
 ## PCF configuration (inputs + outputs)
 ### Inputs (app maker/config)
 The PCF control exposes inputs for:

--- a/docs/svtGetUserContext.md
+++ b/docs/svtGetUserContext.md
@@ -1,0 +1,51 @@
+# voa_SvtGetUserContext Custom API (User Context)
+
+## Purpose
+`voa_SvtGetUserContext` is an **unbound** Dataverse Custom API that resolves the current user’s **SVT persona** (`Manager`, `QA`, or `User`) and returns the matching team/role context. It uses the initiating user ID from the Dataverse execution context and delegates resolution to `UserContextResolver`.【F:VOA.SVT.Plugins/Plugins/CustomAPI/SvtGetUserContext.cs†L24-L56】【F:VOA.SVT.Plugins/Helpers/UserContextResolver.cs†L45-L200】
+
+---
+
+## Resolution logic (teams → roles)
+The resolver checks for SVT **security-group team** membership first, then falls back to **Dataverse roles** if no matching teams are found. The team/role names used for matching are hard-coded in `UserContextConfig` (SVT Manager/QA/User).【F:VOA.SVT.Plugins/Helpers/UserContextResolver.cs†L30-L190】
+
+Persona mapping summary:
+- `SVT Manager Team` / `VOA - SVT Manager` → `Manager`
+- `SVT QA Team` / `VOA - SVT QA` → `QA`
+- `SVT User Team` / `VOA - SVT User` → `User`
+
+---
+
+## Output parameters
+The Custom API writes output parameters directly (not a JSON string). These are the key outputs:
+
+| Output | Type | Description |
+| --- | --- | --- |
+| `svtPersona` | string | Resolved persona (`Manager`, `QA`, `User`, or `None`). |
+| `resolutionSource` | string | `Team`, `Role`, or `None`. |
+| `hasSvtAccess` | boolean | `true` if persona is not `None`. |
+| `matchedTeamName` | string | Team name that matched (if any). |
+| `matchedRoleName` | string | Primary role name that matched (if any). |
+| `matchedRoleNames` | string | Semicolon-delimited list of matched roles. |
+
+These outputs are set by `SvtGetUserContext` after resolution completes.【F:VOA.SVT.Plugins/Plugins/CustomAPI/SvtGetUserContext.cs†L45-L56】
+
+---
+
+## Canvas app usage (App.OnStart)
+Call the Custom API once on app start and store the outputs in a global variable for screen-level logic.
+
+```powerfx
+// App.OnStart
+Set(
+    gblSvtUserContext,
+    voa_SvtGetUserContext.Run()
+);
+
+// Example usage
+Set(gblIsManager, gblSvtUserContext.svtPersona = "Manager");
+```
+
+---
+
+## Related docs
+- `docs/svtTaskAssignment.md` (assignment API authorization uses the same persona mapping).


### PR DESCRIPTION
### Motivation
- Clarify how the system resolves user persona/roles (team → role) for assignment authorization and make it explicit for Canvas app authors.
- Document how assignable users are loaded for the manager assignment panel and how the PCF uses `screenName` to determine assignment context.
- Update task assignment docs to show the `screenName` parameter and authorization flow enforced in the backend plugin.

### Description
- Added `docs/svtGetUserContext.md` describing the `voa_SvtGetUserContext` Custom API, its persona resolution logic, outputs, and Canvas App `App.OnStart` usage (`voa_SvtGetUserContext.Run()` stored in `gblSvtUserContext`).
- Extended `docs/manager-assignment-technical-doc.md` with an "Assignment security context (roles + teams)" section that explains `UserContextResolver`, the `voa_SvtGetUserContext` outputs, and the `voa_SvtGetAssignableUsers` flow that the PCF calls when the assignment panel opens.
- Updated `docs/svtTaskAssignment.md` to add the `screenName` request parameter, document that the plugin resolves persona/assignment context and denies unauthorized operations, and link to the new user-context doc and helpers (`UserContextResolver`, `AssignmentContextResolver`).
- All documentation changes reference the relevant implementation lines in the PCF and plugin code (`DetailsListHost`, `ControlConfig`, `SvtGetUserContext`, `SvtGetAssignableUsers`, `SvtTaskAssignment`, `UserContextResolver`, `AssignmentContextResolver`).

### Testing
- No automated tests were run; this is a documentation-only change and was committed and packaged into a PR without runtime validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978615a060c832cb69fff9b25e09524)